### PR TITLE
Develop

### DIFF
--- a/src/decorators/ensure-initialized.decorator.ts
+++ b/src/decorators/ensure-initialized.decorator.ts
@@ -1,0 +1,15 @@
+import type { BaseRepository } from '../repositories/base.repository'
+
+export function EnsureInitialized(target: BaseRepository<any>, propertyKey: string, descriptor: PropertyDescriptor) {
+  const originalMethod = descriptor.value
+
+  descriptor.value = async function (this: BaseRepository<any>, ...args: any[]) {
+    if (this.initialized === false && typeof this.init === 'function') {
+      await this.init()
+    }
+
+    return originalMethod.apply(this, args)
+  }
+
+  return descriptor
+}

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -1,5 +1,6 @@
 import type { UserEntity } from '../entities/user.entity'
 import { database } from '../config/database'
+import { EnsureInitialized } from '../decorators/ensure-initialized.decorator'
 import { BaseRepository } from './base.repository'
 
 export class UserRepository extends BaseRepository<UserEntity> {
@@ -31,9 +32,8 @@ export class UserRepository extends BaseRepository<UserEntity> {
     })
   }
 
+  @EnsureInitialized
   public async findByTelegramId(telegramId: number): Promise<UserEntity | null> {
-    await this.ensureInitialized()
-
     return this.collection.findOne({ 'telegram_user.id': telegramId })
   }
 }


### PR DESCRIPTION
- Add EnsureInitialized decorator to automate repository initialization logic
- Remove repetitive ensureInitialized() method calls from repository methods
- Delete ensureInitialized() helper method from BaseRepository
- Change initialized property visibility from private to protected
- Apply @EnsureInitialized decorator to repository CRUD methods
- Maintain same functionality while improving code organization and DRY principle
