### PR TITLE
Fix incorrect usage counting logic

### DIFF
--- a/src/handlers/download.handler.spec.ts
+++ b/src/handlers/download.handler.spec.ts
@@ -1,5 +1,6 @@
 import type fs from 'node:fs/promises'
 import type { Browser } from '../config/browser'
+import type { UserRepository } from '../repositories/user.repository'
 import type { CustomContext } from '../types/custom-context.type'
 import { Buffer } from 'node:buffer'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -18,6 +19,7 @@ describe(DownloadHandler.name, () => {
   let handler: DownloadHandler
   let ctx: CustomContext
   let mockBrowser: Browser
+  let mockUserRepository: UserRepository
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -34,8 +36,13 @@ describe(DownloadHandler.name, () => {
       }),
     } as unknown as Browser
 
-    handler = new DownloadHandler(mockBrowser)
+    mockUserRepository = {
+      incrementUsage: vi.fn(),
+    } as unknown as UserRepository
+
+    handler = new DownloadHandler(mockBrowser, mockUserRepository)
     ctx = {
+      from: { id: 123 },
       session: {
         command: null,
         params: { url: null },
@@ -71,6 +78,7 @@ describe(DownloadHandler.name, () => {
 
         expect(mockBrowser.getInstance).toHaveBeenCalled()
         expect(ctx.replyWithDocument).toHaveBeenCalled()
+        expect(mockUserRepository.incrementUsage).toHaveBeenCalledWith(123)
         expect(ctx.session.command).toBeNull()
         expect(ctx.session.params).toBeNull()
       })

--- a/src/handlers/download.handler.ts
+++ b/src/handlers/download.handler.ts
@@ -1,5 +1,6 @@
 import type { Page, PDFOptions } from 'puppeteer'
 import type { Browser } from '../config/browser'
+import type { UserRepository } from '../repositories/user.repository'
 import type { CustomContext } from '../types/custom-context.type'
 import dns from 'node:dns/promises'
 import fs from 'node:fs/promises'
@@ -14,7 +15,10 @@ import { DownloadParamsSchema } from '../schemas/download-params.schema'
 import { BaseHandler } from './base.handler'
 
 export class DownloadHandler extends BaseHandler {
-  constructor(private readonly browser: Browser) {
+  constructor(
+    private readonly browser: Browser,
+    private readonly userRepository: UserRepository,
+  ) {
     super()
   }
 
@@ -67,6 +71,7 @@ export class DownloadHandler extends BaseHandler {
         const document = new InputFile(filePath, `${title}.pdf`)
 
         await ctx.replyWithDocument(document)
+        await this.userRepository.incrementUsage(ctx.from!.id)
       }
       catch (error) {
         this.logger.error(error)

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -14,12 +14,12 @@ import { SummaryHandler } from './summary.handler'
 import { VersionHandler } from './version.handler'
 
 const coreHandlers: Array<BaseHandler> = [
-  new DownloadHandler(browser),
+  new DownloadHandler(browser, userRepository),
   new FeedbackHandler(feedbackRepository),
-  new JoinHandler(),
+  new JoinHandler(userRepository),
   new ProHandler(userRepository, paymentRepository),
-  new PutPasswordHandler(),
-  new SplitHandler(),
+  new PutPasswordHandler(userRepository),
+  new SplitHandler(userRepository),
   new StartHandler(userRepository),
   new SummaryHandler(userRepository, ai),
   new VersionHandler(),

--- a/src/handlers/join.handler.spec.ts
+++ b/src/handlers/join.handler.spec.ts
@@ -1,3 +1,4 @@
+import type { UserRepository } from '../repositories/user.repository'
 import type { JoinParams } from '../schemas/join-params.schema'
 import type { CustomContext } from '../types/custom-context.type'
 import fs from 'node:fs/promises'
@@ -11,13 +12,19 @@ import { JoinHandler } from './join.handler'
 
 describe(JoinHandler.name, () => {
   let handler: JoinHandler
+  let mockUserRepository: UserRepository
 
   let ctx: CustomContext
 
   beforeEach(() => {
     vi.clearAllMocks()
-    handler = new JoinHandler()
+    mockUserRepository = {
+      incrementUsage: vi.fn(),
+    } as unknown as UserRepository
+
+    handler = new JoinHandler(mockUserRepository)
     ctx = {
+      from: { id: 123 },
       session: {
         command: null,
         params: { paths: [] } as JoinParams,
@@ -150,6 +157,7 @@ describe(JoinHandler.name, () => {
         await (handler as any).joinPDFs(ctx)
 
         expect(ctx.reply).toHaveBeenCalledWith('🔄 Merging your PDF files...')
+        expect(mockUserRepository.incrementUsage).toHaveBeenCalledWith(123)
         expect(ctx.replyWithDocument).toHaveBeenCalledWith(
           expect.objectContaining({
             fileData: expect.stringContaining('merged.pdf'),

--- a/src/handlers/join.handler.ts
+++ b/src/handlers/join.handler.ts
@@ -1,3 +1,4 @@
+import type { UserRepository } from '../repositories/user.repository'
 import type { CustomContext } from '../types/custom-context.type'
 import fs from 'node:fs/promises'
 import os from 'node:os'
@@ -9,6 +10,10 @@ import { JoinParamsSchema } from '../schemas/join-params.schema'
 import { BaseHandler } from './base.handler'
 
 export class JoinHandler extends BaseHandler {
+  constructor(private readonly userRepository: UserRepository) {
+    super()
+  }
+
   readonly command = CommandEnum.Join
   readonly description = '🔗 Join multiple PDF files into one'
   static readonly MAX_PDF_FILES = 10
@@ -80,6 +85,7 @@ export class JoinHandler extends BaseHandler {
       await ctx.replyWithDocument(new InputFile(outputPath, 'merged.pdf'), {
         caption: '✅ Here is your joined PDF file!',
       })
+      await this.userRepository.incrementUsage(ctx.from!.id)
     }
     catch (error) {
       this.logger.error(error)

--- a/src/handlers/put-password.handler.spec.ts
+++ b/src/handlers/put-password.handler.spec.ts
@@ -1,3 +1,4 @@
+import type { UserRepository } from '../repositories/user.repository'
 import type { CustomContext } from '../types/custom-context.type'
 import fs from 'node:fs/promises'
 import os from 'node:os'
@@ -19,11 +20,17 @@ vi.mock('../config/bot', () => ({
 describe(PutPasswordHandler.name, () => {
   let handler: PutPasswordHandler
   let ctx: CustomContext
+  let mockUserRepository: UserRepository
 
   beforeEach(() => {
     vi.clearAllMocks()
-    handler = new PutPasswordHandler()
+    mockUserRepository = {
+      incrementUsage: vi.fn(),
+    } as unknown as UserRepository
+
+    handler = new PutPasswordHandler(mockUserRepository)
     ctx = {
+      from: { id: 123 },
       session: {
         command: null,
         params: { path: null },
@@ -38,7 +45,7 @@ describe(PutPasswordHandler.name, () => {
       chat: { id: 100 },
       getFile: vi.fn(),
       reply: vi.fn(),
-      replyWithDocument: vi.fn(),
+      replyWithDocument: vi.fn().mockResolvedValue({}),
     } as unknown as CustomContext
   })
 
@@ -99,6 +106,7 @@ describe(PutPasswordHandler.name, () => {
           expect(ctx.replyWithDocument).toHaveBeenCalledWith(expect.any(InputFile), {
             caption: '✅ Here is your password-protected PDF!',
           })
+          expect(mockUserRepository.incrementUsage).toHaveBeenCalledWith(123)
           expect(ctx.session.command).toBeNull()
           expect(ctx.session.params).toBeNull()
         }

--- a/src/handlers/put-password.handler.ts
+++ b/src/handlers/put-password.handler.ts
@@ -1,3 +1,4 @@
+import type { UserRepository } from '../repositories/user.repository'
 import type { CustomContext } from '../types/custom-context.type'
 import fs from 'node:fs/promises'
 import os from 'node:os'
@@ -11,6 +12,10 @@ import { PutPasswordParamsSchema } from '../schemas/put-password-params.schema'
 import { BaseHandler } from './base.handler'
 
 export class PutPasswordHandler extends BaseHandler {
+  constructor(private readonly userRepository: UserRepository) {
+    super()
+  }
+
   public readonly command = CommandEnum.PutPassword
   public readonly description = '🔐 Protect a PDF with a password'
   public readonly events = {
@@ -58,7 +63,10 @@ export class PutPasswordHandler extends BaseHandler {
               ctx.replyWithDocument(new InputFile(output), {
                 caption: '✅ Here is your password-protected PDF!',
               })
-                .then(() => resolve())
+                .then(async () => {
+                  await this.userRepository.incrementUsage(ctx.from!.id)
+                  resolve()
+                })
                 .catch(reject)
             })
         })

--- a/src/handlers/split.handler.spec.ts
+++ b/src/handlers/split.handler.spec.ts
@@ -1,3 +1,4 @@
+import type { UserRepository } from '../repositories/user.repository'
 import type { CustomContext } from '../types/custom-context.type'
 import fs from 'node:fs/promises'
 import os from 'node:os'
@@ -7,12 +8,18 @@ import { CommandEnum } from '../enums/command.enum'
 import { SplitHandler } from './split.handler'
 
 describe(SplitHandler.name, () => {
-  const handler = new SplitHandler()
+  let handler: SplitHandler
+  let mockUserRepository: UserRepository
 
   let ctx: CustomContext
 
   beforeEach(() => {
+    mockUserRepository = {
+      incrementUsage: vi.fn(),
+    } as unknown as UserRepository
+    handler = new SplitHandler(mockUserRepository)
     ctx = {
+      from: { id: 123 },
       session: {
         command: null,
         params: {} as any,
@@ -59,6 +66,7 @@ describe(SplitHandler.name, () => {
 
           expect(ctx.getFile).toHaveBeenCalled()
           expect(ctx.reply).toHaveBeenCalledWith('📄 Found 10 pages. Splitting...')
+          expect(mockUserRepository.incrementUsage).toHaveBeenCalledWith(123)
 
           for (let i = 0; i < 10; i++) {
             expect(ctx.replyWithDocument).toHaveBeenCalledWith(

--- a/src/handlers/split.handler.ts
+++ b/src/handlers/split.handler.ts
@@ -1,3 +1,4 @@
+import type { UserRepository } from '../repositories/user.repository'
 import type { CustomContext } from '../types/custom-context.type'
 import fs from 'node:fs/promises'
 import os from 'node:os'
@@ -8,6 +9,10 @@ import { CommandEnum } from '../enums/command.enum'
 import { BaseHandler } from './base.handler'
 
 export class SplitHandler extends BaseHandler {
+  constructor(private readonly userRepository: UserRepository) {
+    super()
+  }
+
   readonly command = CommandEnum.Split
   readonly description = '✂️ Split a PDF into individual pages'
   readonly events = {
@@ -55,6 +60,8 @@ export class SplitHandler extends BaseHandler {
             caption: `📄 Page ${pageNumber} of ${pagesCount}`,
           })
         }
+
+        await this.userRepository.incrementUsage(ctx.from!.id)
       }
       catch (error) {
         this.logger.error(error)

--- a/src/handlers/summary.handler.spec.ts
+++ b/src/handlers/summary.handler.spec.ts
@@ -27,6 +27,7 @@ const mockAi = {
 describe(SummaryHandler.name, () => {
   const mockUserRepository = {
     findByTelegramId: vi.fn(),
+    incrementUsage: vi.fn(),
   } as unknown as UserRepository
 
   const handler = new SummaryHandler(mockUserRepository, mockAi)
@@ -57,6 +58,13 @@ describe(SummaryHandler.name, () => {
       },
     } as unknown as CustomContext
   })
+
+  const mockUserWithId = (id: number, plan: PlanTypeEnum) => {
+    vi.mocked(mockUserRepository.findByTelegramId).mockResolvedValue({
+      telegram_user: { id },
+      plan_type: plan,
+    } as any)
+  }
 
   const setupTestFile = async (prefix: string) => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), prefix))
@@ -110,13 +118,15 @@ describe(SummaryHandler.name, () => {
         const { tempDir, targetPath } = await setupTestFile('pdf-studio-bot-test-summary-')
 
         try {
-          mockUserWithPlan(PlanTypeEnum.Free)
+          mockUserWithId(123, PlanTypeEnum.Free)
 
           mockGenerateContent.mockResolvedValueOnce({
             text: 'This is a mock summary of the PDF.',
           })
 
           await handler.events['msg:document'](ctx)
+
+          expect(mockUserRepository.incrementUsage).toHaveBeenCalledWith(123)
 
           // Since page-1.pdf has 10 pages and <10MB, it should pass limits.
           expect(ctx.reply).toHaveBeenCalledWith('⏳ Summarizing your PDF. This might take a moment...')

--- a/src/handlers/summary.handler.ts
+++ b/src/handlers/summary.handler.ts
@@ -48,6 +48,7 @@ export class SummaryHandler extends BaseHandler {
         })
 
         await this.sendSummaryResponse(ctx, processingMessage.message_id, text)
+        await this.userRepository.incrementUsage(ctx.from!.id)
       }
       catch (error) {
         if (error instanceof LimitExceededError)

--- a/src/middlewares/usage-limit.middleware.spec.ts
+++ b/src/middlewares/usage-limit.middleware.spec.ts
@@ -8,6 +8,7 @@ vi.mock('../repositories', () => ({
     findByTelegramId: vi.fn(),
     create: vi.fn(),
     incrementUsage: vi.fn(),
+    isWithinLimit: vi.fn(),
     updateById: vi.fn(),
   },
 }))
@@ -49,20 +50,20 @@ describe(usageLimitMiddleware.name, () => {
     expect(userRepository.findByTelegramId).not.toHaveBeenCalled()
   })
 
-  it('should create user and increment usage if user does not exist', async () => {
+  it('should create user and check limit if user does not exist', async () => {
     vi.mocked(userRepository.findByTelegramId).mockResolvedValueOnce(null)
     const newUser = {
       _id: 'new-id',
       plan_type: PlanTypeEnum.Free,
     }
     vi.mocked(userRepository.create).mockResolvedValueOnce(newUser as any)
-    vi.mocked(userRepository.incrementUsage).mockResolvedValueOnce({ ...newUser, daily_usage_count: 1 } as any)
+    vi.mocked(userRepository.isWithinLimit).mockResolvedValueOnce(true)
 
     const middleware = usageLimitMiddleware(handler)
     await middleware(ctx, next)
 
     expect(userRepository.create).toHaveBeenCalled()
-    expect(userRepository.incrementUsage).toHaveBeenCalledWith(12345, 3)
+    expect(userRepository.isWithinLimit).toHaveBeenCalledWith(12345, 3)
     expect(next).toHaveBeenCalled()
   })
 
@@ -72,7 +73,7 @@ describe(usageLimitMiddleware.name, () => {
       plan_type: PlanTypeEnum.Free,
     }
     vi.mocked(userRepository.findByTelegramId).mockResolvedValueOnce(user as any)
-    vi.mocked(userRepository.incrementUsage).mockResolvedValueOnce(null)
+    vi.mocked(userRepository.isWithinLimit).mockResolvedValueOnce(false)
 
     const middleware = usageLimitMiddleware(handler)
     await middleware(ctx, next)
@@ -87,7 +88,7 @@ describe(usageLimitMiddleware.name, () => {
       plan_type: PlanTypeEnum.Pro,
     }
     vi.mocked(userRepository.findByTelegramId).mockResolvedValueOnce(user as any)
-    vi.mocked(userRepository.incrementUsage).mockResolvedValueOnce(null)
+    vi.mocked(userRepository.isWithinLimit).mockResolvedValueOnce(false)
 
     const middleware = usageLimitMiddleware(handler)
     await middleware(ctx, next)
@@ -102,13 +103,13 @@ describe(usageLimitMiddleware.name, () => {
       plan_type: PlanTypeEnum.Pro,
     }
     vi.mocked(userRepository.findByTelegramId).mockResolvedValueOnce(user as any)
-    vi.mocked(userRepository.incrementUsage).mockResolvedValueOnce({ ...user, daily_usage_count: 11 } as any)
+    vi.mocked(userRepository.isWithinLimit).mockResolvedValueOnce(true)
 
     const middleware = usageLimitMiddleware(handler)
     await middleware(ctx, next)
 
     expect(next).toHaveBeenCalled()
-    expect(userRepository.incrementUsage).toHaveBeenCalledWith(12345, 50)
+    expect(userRepository.isWithinLimit).toHaveBeenCalledWith(12345, 50)
   })
 
   it('should revert to Free if Pro plan has expired', async () => {
@@ -121,7 +122,7 @@ describe(usageLimitMiddleware.name, () => {
       plan_started_at: expiredDate,
     }
     vi.mocked(userRepository.findByTelegramId).mockResolvedValueOnce(user as any)
-    vi.mocked(userRepository.incrementUsage).mockResolvedValueOnce({ ...user, plan_type: PlanTypeEnum.Free, daily_usage_count: 1 } as any)
+    vi.mocked(userRepository.isWithinLimit).mockResolvedValueOnce(true)
 
     const middleware = usageLimitMiddleware(handler)
     await middleware(ctx, next)
@@ -130,7 +131,7 @@ describe(usageLimitMiddleware.name, () => {
       plan_type: PlanTypeEnum.Free,
       plan_started_at: null,
     })
-    expect(userRepository.incrementUsage).toHaveBeenCalledWith(12345, 3)
+    expect(userRepository.isWithinLimit).toHaveBeenCalledWith(12345, 3)
     expect(next).toHaveBeenCalled()
   })
 })

--- a/src/middlewares/usage-limit.middleware.ts
+++ b/src/middlewares/usage-limit.middleware.ts
@@ -39,9 +39,9 @@ export function usageLimitMiddleware(handler: BaseHandler) {
 
     const limit = limits[user.plan_type || PlanTypeEnum.Free]
 
-    const updatedUser = await userRepository.incrementUsage(ctx.from!.id, limit)
+    const isWithinLimit = await userRepository.isWithinLimit(ctx.from!.id, limit)
 
-    if (!updatedUser) {
+    if (!isWithinLimit) {
       if (user.plan_type === PlanTypeEnum.Pro) {
         await ctx.reply('⚠️ You have reached your daily limit of 50 operations. As a PRO user, this is our safety limit. Please try again tomorrow.')
       }

--- a/src/repositories/user.repository.spec.ts
+++ b/src/repositories/user.repository.spec.ts
@@ -135,5 +135,58 @@ describe(UserRepository.name, () => {
 
       expect(user).toBeNull()
     })
+
+    it('should increment without limit check if limit is not provided', async () => {
+      await userRepository.create(new UserEntity({
+        telegram_user: { id: 30, is_bot: false, first_name: 'Test' },
+        daily_usage_count: 5,
+        last_usage_date: new Date().toISOString().split('T')[0],
+      }))
+
+      const user = await userRepository.incrementUsage(30)
+
+      expect(user).toBeDefined()
+      expect(user?.daily_usage_count).toBe(6)
+    })
+  })
+
+  describe(UserRepository.prototype.isWithinLimit.name, () => {
+    it('should return true if user does not exist', async () => {
+      const isWithin = await userRepository.isWithinLimit(8888, 3)
+      expect(isWithin).toBe(true)
+    })
+
+    it('should return true if it is a new day', async () => {
+      await userRepository.create(new UserEntity({
+        telegram_user: { id: 40, is_bot: false, first_name: 'Test' },
+        daily_usage_count: 5,
+        last_usage_date: '2000-01-01',
+      }))
+
+      const isWithin = await userRepository.isWithinLimit(40, 3)
+      expect(isWithin).toBe(true)
+    })
+
+    it('should return true if within limit', async () => {
+      await userRepository.create(new UserEntity({
+        telegram_user: { id: 41, is_bot: false, first_name: 'Test' },
+        daily_usage_count: 2,
+        last_usage_date: new Date().toISOString().split('T')[0],
+      }))
+
+      const isWithin = await userRepository.isWithinLimit(41, 3)
+      expect(isWithin).toBe(true)
+    })
+
+    it('should return false if limit reached', async () => {
+      await userRepository.create(new UserEntity({
+        telegram_user: { id: 42, is_bot: false, first_name: 'Test' },
+        daily_usage_count: 3,
+        last_usage_date: new Date().toISOString().split('T')[0],
+      }))
+
+      const isWithin = await userRepository.isWithinLimit(42, 3)
+      expect(isWithin).toBe(false)
+    })
   })
 })

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -53,22 +53,44 @@ export class UserRepository extends BaseRepository<UserEntity> {
   }
 
   @EnsureInitialized
-  public async incrementUsage(telegramId: number, limit: number): Promise<UserEntity | null> {
+  public async isWithinLimit(telegramId: number, limit: number): Promise<boolean> {
     const today = new Date().toISOString().split('T')[0]
 
+    const user = await this.collection.findOne({
+      'telegram_user.id': telegramId,
+    })
+
+    if (!user) {
+      return true
+    }
+
+    if (user.last_usage_date !== today) {
+      return true
+    }
+
+    return (user.daily_usage_count || 0) < limit
+  }
+
+  @EnsureInitialized
+  public async incrementUsage(telegramId: number, limit?: number): Promise<UserEntity | null> {
+    const today = new Date().toISOString().split('T')[0]
+
+    const filter: any = { 'telegram_user.id': telegramId }
+
+    if (limit !== undefined) {
+      filter.$or = [
+        { last_usage_date: { $ne: today } },
+        {
+          $and: [
+            { last_usage_date: today },
+            { daily_usage_count: { $lt: limit } },
+          ],
+        },
+      ]
+    }
+
     const result = await this.collection.findOneAndUpdate(
-      {
-        'telegram_user.id': telegramId,
-        '$or': [
-          { last_usage_date: { $ne: today } },
-          {
-            $and: [
-              { last_usage_date: today },
-              { daily_usage_count: { $lt: limit } },
-            ],
-          },
-        ],
-      },
+      filter,
       [
         {
           $set: {


### PR DESCRIPTION
This PR fixes a bug where the daily usage count was being incremented for every message sent by the user, leading to incorrect usage tracking.

Key changes:
- `UserRepository`: Introduced `isWithinLimit` to check limits without side effects. Made `limit` optional in `incrementUsage` to allow incrementing without a prior check when the limit has already been validated.
- `usageLimitMiddleware`: Now uses `isWithinLimit` to only authorize the operation, not to count it.
- Handlers (`Download`, `Join`, `PutPassword`, `Split`, `Summary`): Now explicitly call `userRepository.incrementUsage` only after the main task (e.g., merging, splitting, summarizing) has been successfully finished.
- Tests: Updated existing tests and added new ones to ensure that the limit is checked at the start and the usage is only recorded at the end of a successful operation.

---
*PR created automatically by Jules for task [5023731558607645046](https://jules.google.com/task/5023731558607645046) started by @gabrielrufino*