### PR TITLE
Add PDF to images operation

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "grammy": "^1.42.0",
     "mongodb": "^6.21.0",
     "muhammara": "^5.4.0",
+    "pdf-to-img": "^6.0.0",
     "pino": "^9.14.0",
     "pino-loki": "^3.0.0",
     "puppeteer": "^24.42.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       muhammara:
         specifier: ^5.4.0
         version: 5.4.0
+      pdf-to-img:
+        specifier: ^6.0.0
+        version: 6.0.0
       pino:
         specifier: ^9.14.0
         version: 9.14.0
@@ -863,6 +866,81 @@ packages:
 
   '@mongodb-js/saslprep@1.4.9':
     resolution: {integrity: sha512-RXSxsokhAF/4nWys8An8npsqOI33Ex1Hlzqjw2pZOO+GKtMAR2noGnUdsFiGwsaO/xXI+56mtjTmDA3JXJsvmA==}
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    resolution: {integrity: sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.100':
+    resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -3062,6 +3140,9 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  node-readable-to-web-readable-stream@0.4.2:
+    resolution: {integrity: sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==}
+
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
@@ -3187,6 +3268,15 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pdf-to-img@6.0.0:
+    resolution: {integrity: sha512-ZFFubmTBWCqqGdiAkoK4QrsGw8PdIflr1E1hCWW4h/r/pr395zjMFF6eYFYLJtbTuGnGFzqoNUfsbafG+H3joA==}
+    engines: {node: '>=20.19.0 || >=22.13.0 || >=24'}
+    hasBin: true
+
+  pdfjs-dist@5.6.205:
+    resolution: {integrity: sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg==}
+    engines: {node: '>=20.19.0 || >=22.13.0 || >=24'}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -4776,6 +4866,54 @@ snapshots:
   '@mongodb-js/saslprep@1.4.9':
     dependencies:
       sparse-bitfield: 3.0.3
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas@0.1.100':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-x64': 0.1.100
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.100
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.100
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-musl': 0.1.100
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.100
+    optional: true
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -7078,6 +7216,9 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
+  node-readable-to-web-readable-stream@0.4.2:
+    optional: true
+
   node-releases@2.0.38: {}
 
   nopt@8.1.0:
@@ -7204,6 +7345,15 @@ snapshots:
   path-parse@1.0.7: {}
 
   pathe@2.0.3: {}
+
+  pdf-to-img@6.0.0:
+    dependencies:
+      pdfjs-dist: 5.6.205
+
+  pdfjs-dist@5.6.205:
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.100
+      node-readable-to-web-readable-stream: 0.4.2
 
   pend@1.2.0: {}
 

--- a/src/enums/command.enum.ts
+++ b/src/enums/command.enum.ts
@@ -3,6 +3,7 @@ export enum CommandEnum {
   Feedback = 'feedback',
   Help = 'help',
   Join = 'join',
+  PdfToImages = 'pdftoimages',
   Pro = 'pro',
   PutPassword = 'putpassword',
   Split = 'split',

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -6,6 +6,7 @@ import { DownloadHandler } from './download.handler'
 import { FeedbackHandler } from './feedback.handler'
 import { HelpHandler } from './help.handler'
 import { JoinHandler } from './join.handler'
+import { PdfToImagesHandler } from './pdf-to-images.handler'
 import { ProHandler } from './pro.handler'
 import { PutPasswordHandler } from './put-password.handler'
 import { SplitHandler } from './split.handler'
@@ -17,6 +18,7 @@ const coreHandlers: Array<BaseHandler> = [
   new DownloadHandler(browser, userRepository),
   new FeedbackHandler(feedbackRepository),
   new JoinHandler(userRepository),
+  new PdfToImagesHandler(userRepository),
   new ProHandler(userRepository, paymentRepository),
   new PutPasswordHandler(userRepository),
   new SplitHandler(userRepository),

--- a/src/handlers/pdf-to-images.handler.spec.ts
+++ b/src/handlers/pdf-to-images.handler.spec.ts
@@ -9,6 +9,9 @@ import { PdfToImagesHandler } from './pdf-to-images.handler'
 vi.mock('node:fs/promises', () => ({
   default: {
     rm: vi.fn().mockResolvedValue(undefined),
+    mkdtemp: vi.fn().mockResolvedValue('/tmp/pdf-studio-bot-pdf-to-images-test'),
+    chmod: vi.fn().mockResolvedValue(undefined),
+    writeFile: vi.fn().mockResolvedValue(undefined),
   },
 }))
 vi.mock('pdf-to-img')

--- a/src/handlers/pdf-to-images.handler.spec.ts
+++ b/src/handlers/pdf-to-images.handler.spec.ts
@@ -4,6 +4,7 @@ import { Buffer } from 'node:buffer'
 import { pdf } from 'pdf-to-img'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { CommandEnum } from '../enums/command.enum'
+import { PlanTypeEnum } from '../enums/plan-type.enum'
 import { PdfToImagesHandler } from './pdf-to-images.handler'
 
 vi.mock('node:fs/promises', () => ({
@@ -12,9 +13,17 @@ vi.mock('node:fs/promises', () => ({
     mkdtemp: vi.fn().mockResolvedValue('/tmp/pdf-studio-bot-pdf-to-images-test'),
     chmod: vi.fn().mockResolvedValue(undefined),
     writeFile: vi.fn().mockResolvedValue(undefined),
+    stat: vi.fn().mockResolvedValue({ size: 100 }),
   },
 }))
 vi.mock('pdf-to-img')
+vi.mock('muhammara', () => ({
+  default: {
+    createReader: vi.fn().mockReturnValue({
+      getPagesCount: vi.fn().mockReturnValue(2),
+    }),
+  },
+}))
 
 describe(PdfToImagesHandler.name, () => {
   let handler: PdfToImagesHandler
@@ -26,6 +35,7 @@ describe(PdfToImagesHandler.name, () => {
 
     mockUserRepository = {
       incrementUsage: vi.fn(),
+      findByTelegramId: vi.fn().mockResolvedValue({ plan_type: PlanTypeEnum.Pro }),
     } as unknown as UserRepository
 
     handler = new PdfToImagesHandler(mockUserRepository)

--- a/src/handlers/pdf-to-images.handler.spec.ts
+++ b/src/handlers/pdf-to-images.handler.spec.ts
@@ -5,7 +5,6 @@ import { pdf } from 'pdf-to-img'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { CommandEnum } from '../enums/command.enum'
 import { PlanTypeEnum } from '../enums/plan-type.enum'
-import { InvalidFileError } from '../errors/invalid-file.error'
 import { PdfToImagesHandler } from './pdf-to-images.handler'
 
 vi.mock('node:fs/promises', () => ({
@@ -77,7 +76,16 @@ describe(PdfToImagesHandler.name, () => {
 
   describe('events', () => {
     describe('msg:document', () => {
+      it('should return early if command is not PdfToImages', async () => {
+        ctx.session.command = CommandEnum.Split
+
+        await handler.events['msg:document'](ctx)
+
+        expect(ctx.getFile).not.toHaveBeenCalled()
+      })
+
       it('should convert PDF to images and send them as a media group', async () => {
+        ctx.session.command = CommandEnum.PdfToImages
         const mockImages = [Buffer.from([1, 2, 3]), Buffer.from([4, 5, 6])]
         const mockDocument = {
           length: 2,
@@ -95,6 +103,7 @@ describe(PdfToImagesHandler.name, () => {
       })
 
       it('should handle errors during conversion', async () => {
+        ctx.session.command = CommandEnum.PdfToImages
         vi.mocked(pdf).mockRejectedValue(new Error('Conversion failed'))
 
         await handler.events['msg:document'](ctx)
@@ -103,6 +112,7 @@ describe(PdfToImagesHandler.name, () => {
       })
 
       it('should not reply with generic error if file is not a PDF (InvalidFileError)', async () => {
+        ctx.session.command = CommandEnum.PdfToImages
         ctx.message!.document!.mime_type = 'image/png'
 
         await handler.events['msg:document'](ctx)

--- a/src/handlers/pdf-to-images.handler.spec.ts
+++ b/src/handlers/pdf-to-images.handler.spec.ts
@@ -1,8 +1,8 @@
-import type fs from 'node:fs/promises'
 import type { UserRepository } from '../repositories/user.repository'
 import type { CustomContext } from '../types/custom-context.type'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Buffer } from 'node:buffer'
 import { pdf } from 'pdf-to-img'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { CommandEnum } from '../enums/command.enum'
 import { PdfToImagesHandler } from './pdf-to-images.handler'
 

--- a/src/handlers/pdf-to-images.handler.spec.ts
+++ b/src/handlers/pdf-to-images.handler.spec.ts
@@ -65,7 +65,7 @@ describe(PdfToImagesHandler.name, () => {
       it('should convert PDF to images and send them', async () => {
         const mockImages = [Buffer.from([1, 2, 3]), Buffer.from([4, 5, 6])]
         const mockDocument = {
-          getPageCount: vi.fn().mockReturnValue(2),
+          length: 2,
           [Symbol.asyncIterator]: vi.fn().mockReturnValue(mockImages[Symbol.iterator]()),
         }
         vi.mocked(pdf).mockResolvedValue(mockDocument as any)

--- a/src/handlers/pdf-to-images.handler.spec.ts
+++ b/src/handlers/pdf-to-images.handler.spec.ts
@@ -1,0 +1,95 @@
+import type fs from 'node:fs/promises'
+import type { UserRepository } from '../repositories/user.repository'
+import type { CustomContext } from '../types/custom-context.type'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { pdf } from 'pdf-to-img'
+import { CommandEnum } from '../enums/command.enum'
+import { PdfToImagesHandler } from './pdf-to-images.handler'
+
+vi.mock('node:fs/promises', () => ({
+  default: {
+    rm: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+vi.mock('pdf-to-img')
+
+describe(PdfToImagesHandler.name, () => {
+  let handler: PdfToImagesHandler
+  let ctx: CustomContext
+  let mockUserRepository: UserRepository
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockUserRepository = {
+      incrementUsage: vi.fn(),
+    } as unknown as UserRepository
+
+    handler = new PdfToImagesHandler(mockUserRepository)
+    ctx = {
+      from: { id: 123 },
+      session: {
+        command: null,
+      },
+      message: {
+        document: {
+          mime_type: 'application/pdf',
+        },
+      },
+      getFile: vi.fn().mockResolvedValue({
+        download: vi.fn().mockResolvedValue('/tmp/test.pdf'),
+      }),
+      reply: vi.fn(),
+      replyWithPhoto: vi.fn(),
+    } as unknown as CustomContext
+  })
+
+  it('should have correct command', () => {
+    expect(handler.command).toBe(CommandEnum.PdfToImages)
+  })
+
+  describe(PdfToImagesHandler.prototype.onCommand.name, () => {
+    it('should set session command and ask for PDF', async () => {
+      await handler.onCommand(ctx)
+
+      expect(ctx.reply).toHaveBeenCalledWith('Please send the PDF file you want to convert to images.')
+      expect(ctx.session.command).toBe(CommandEnum.PdfToImages)
+    })
+  })
+
+  describe('events', () => {
+    describe('msg:document', () => {
+      it('should convert PDF to images and send them', async () => {
+        const mockImages = [Buffer.from([1, 2, 3]), Buffer.from([4, 5, 6])]
+        const mockDocument = {
+          getPageCount: vi.fn().mockReturnValue(2),
+          [Symbol.asyncIterator]: vi.fn().mockReturnValue(mockImages[Symbol.iterator]()),
+        }
+        vi.mocked(pdf).mockResolvedValue(mockDocument as any)
+
+        await handler.events['msg:document'](ctx)
+
+        expect(ctx.getFile).toHaveBeenCalled()
+        expect(pdf).toHaveBeenCalledWith('/tmp/test.pdf')
+        expect(ctx.reply).toHaveBeenCalledWith('🖼️ Converting 2 pages to images...')
+        expect(ctx.replyWithPhoto).toHaveBeenCalledTimes(2)
+        expect(mockUserRepository.incrementUsage).toHaveBeenCalledWith(123)
+      })
+
+      it('should handle errors during conversion', async () => {
+        vi.mocked(pdf).mockRejectedValue(new Error('Conversion failed'))
+
+        await handler.events['msg:document'](ctx)
+
+        expect(ctx.reply).toHaveBeenCalledWith('❌ An error occurred while converting the PDF to images.')
+      })
+
+      it('should reply with error if file is not a PDF', async () => {
+        ctx.message!.document!.mime_type = 'image/png'
+
+        await expect(handler.events['msg:document'](ctx)).rejects.toThrow()
+        expect(ctx.reply).toHaveBeenCalledWith('⚠️ Please send only PDF files.')
+      })
+    })
+  })
+})

--- a/src/handlers/pdf-to-images.handler.spec.ts
+++ b/src/handlers/pdf-to-images.handler.spec.ts
@@ -105,7 +105,8 @@ describe(PdfToImagesHandler.name, () => {
       it('should not reply with generic error if file is not a PDF (InvalidFileError)', async () => {
         ctx.message!.document!.mime_type = 'image/png'
 
-        await expect(handler.events['msg:document'](ctx)).rejects.toThrow(InvalidFileError)
+        await handler.events['msg:document'](ctx)
+
         expect(ctx.reply).toHaveBeenCalledWith('⚠️ Please send only PDF files.')
         expect(ctx.reply).not.toHaveBeenCalledWith('❌ An error occurred while converting the PDF to images.')
       })

--- a/src/handlers/pdf-to-images.handler.spec.ts
+++ b/src/handlers/pdf-to-images.handler.spec.ts
@@ -5,6 +5,7 @@ import { pdf } from 'pdf-to-img'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { CommandEnum } from '../enums/command.enum'
 import { PlanTypeEnum } from '../enums/plan-type.enum'
+import { InvalidFileError } from '../errors/invalid-file.error'
 import { PdfToImagesHandler } from './pdf-to-images.handler'
 
 vi.mock('node:fs/promises', () => ({
@@ -41,6 +42,7 @@ describe(PdfToImagesHandler.name, () => {
     handler = new PdfToImagesHandler(mockUserRepository)
     ctx = {
       from: { id: 123 },
+      chat: { id: 456 },
       session: {
         command: null,
       },
@@ -54,6 +56,9 @@ describe(PdfToImagesHandler.name, () => {
       }),
       reply: vi.fn(),
       replyWithPhoto: vi.fn(),
+      api: {
+        sendMediaGroup: vi.fn(),
+      },
     } as unknown as CustomContext
   })
 
@@ -72,7 +77,7 @@ describe(PdfToImagesHandler.name, () => {
 
   describe('events', () => {
     describe('msg:document', () => {
-      it('should convert PDF to images and send them', async () => {
+      it('should convert PDF to images and send them as a media group', async () => {
         const mockImages = [Buffer.from([1, 2, 3]), Buffer.from([4, 5, 6])]
         const mockDocument = {
           length: 2,
@@ -85,7 +90,7 @@ describe(PdfToImagesHandler.name, () => {
         expect(ctx.getFile).toHaveBeenCalled()
         expect(pdf).toHaveBeenCalledWith('/tmp/test.pdf')
         expect(ctx.reply).toHaveBeenCalledWith('🖼️ Converting 2 pages to images...')
-        expect(ctx.replyWithPhoto).toHaveBeenCalledTimes(2)
+        expect(ctx.api.sendMediaGroup).toHaveBeenCalledWith(456, expect.any(Array))
         expect(mockUserRepository.incrementUsage).toHaveBeenCalledWith(123)
       })
 
@@ -97,11 +102,12 @@ describe(PdfToImagesHandler.name, () => {
         expect(ctx.reply).toHaveBeenCalledWith('❌ An error occurred while converting the PDF to images.')
       })
 
-      it('should reply with error if file is not a PDF', async () => {
+      it('should not reply with generic error if file is not a PDF (InvalidFileError)', async () => {
         ctx.message!.document!.mime_type = 'image/png'
 
-        await expect(handler.events['msg:document'](ctx)).rejects.toThrow()
+        await expect(handler.events['msg:document'](ctx)).rejects.toThrow(InvalidFileError)
         expect(ctx.reply).toHaveBeenCalledWith('⚠️ Please send only PDF files.')
+        expect(ctx.reply).not.toHaveBeenCalledWith('❌ An error occurred while converting the PDF to images.')
       })
     })
   })

--- a/src/handlers/pdf-to-images.handler.ts
+++ b/src/handlers/pdf-to-images.handler.ts
@@ -1,5 +1,6 @@
 import type { UserRepository } from '../repositories/user.repository'
 import type { CustomContext } from '../types/custom-context.type'
+import { Buffer } from 'node:buffer'
 import fs from 'node:fs/promises'
 import { InputFile } from 'grammy'
 import { pdf } from 'pdf-to-img'
@@ -34,7 +35,7 @@ export class PdfToImagesHandler extends BaseHandler {
         await ctx.reply(`🖼️ Converting ${totalPages} pages to images...`)
 
         for await (const image of document) {
-          const imageFile = new InputFile(image, `page-${pageNumber}.png`)
+          const imageFile = new InputFile(Buffer.from(image), `page-${pageNumber}.png`)
 
           await ctx.replyWithPhoto(imageFile, {
             caption: `🖼️ Page ${pageNumber} of ${totalPages}`,

--- a/src/handlers/pdf-to-images.handler.ts
+++ b/src/handlers/pdf-to-images.handler.ts
@@ -36,7 +36,7 @@ export class PdfToImagesHandler extends BaseHandler {
 
         const document = await pdf(inputPath)
         let pageNumber = 1
-        const totalPages = document.getPageCount()
+        const totalPages = document.length
 
         await ctx.reply(`🖼️ Converting ${totalPages} pages to images...`)
 

--- a/src/handlers/pdf-to-images.handler.ts
+++ b/src/handlers/pdf-to-images.handler.ts
@@ -2,6 +2,8 @@ import type { UserRepository } from '../repositories/user.repository'
 import type { CustomContext } from '../types/custom-context.type'
 import { Buffer } from 'node:buffer'
 import fs from 'node:fs/promises'
+import os from 'node:os'
+import { join } from 'node:path'
 import { InputFile } from 'grammy'
 import { pdf } from 'pdf-to-img'
 import { CommandEnum } from '../enums/command.enum'
@@ -19,8 +21,12 @@ export class PdfToImagesHandler extends BaseHandler {
       await this.validatePDF(ctx)
 
       let inputPath: string | undefined
+      let outputDir: string | undefined
 
       try {
+        outputDir = await fs.mkdtemp(join(os.tmpdir(), 'pdf-studio-bot-pdf-to-images-'))
+        await fs.chmod(outputDir, 0o700)
+
         const file = await ctx.getFile()
         inputPath = await file.download()
 
@@ -35,7 +41,10 @@ export class PdfToImagesHandler extends BaseHandler {
         await ctx.reply(`🖼️ Converting ${totalPages} pages to images...`)
 
         for await (const image of document) {
-          const imageFile = new InputFile(Buffer.from(image), `page-${pageNumber}.png`)
+          const imagePath = join(outputDir, `page-${pageNumber}.png`)
+          await fs.writeFile(imagePath, Buffer.from(image))
+
+          const imageFile = new InputFile(imagePath, `page-${pageNumber}.png`)
 
           await ctx.replyWithPhoto(imageFile, {
             caption: `🖼️ Page ${pageNumber} of ${totalPages}`,
@@ -50,6 +59,10 @@ export class PdfToImagesHandler extends BaseHandler {
         await ctx.reply('❌ An error occurred while converting the PDF to images.')
       }
       finally {
+        if (outputDir) {
+          await fs.rm(outputDir, { force: true, recursive: true }).catch(error =>
+            this.logger.error({ error, path: outputDir }, 'Failed to remove temporary folder.'))
+        }
         if (inputPath) {
           await fs.rm(inputPath, { force: true }).catch(error =>
             this.logger.error({ error, path: inputPath }, 'Failed to remove input file.'))

--- a/src/handlers/pdf-to-images.handler.ts
+++ b/src/handlers/pdf-to-images.handler.ts
@@ -26,6 +26,10 @@ export class PdfToImagesHandler extends BaseHandler {
   readonly description = '🖼️ Convert PDF pages to images'
   readonly events = {
     'msg:document': async (ctx: CustomContext) => {
+      if (ctx.session.command !== CommandEnum.PdfToImages) {
+        return
+      }
+
       let inputPath: string | undefined
       let outputDir: string | undefined
 

--- a/src/handlers/pdf-to-images.handler.ts
+++ b/src/handlers/pdf-to-images.handler.ts
@@ -1,15 +1,21 @@
 import type { UserRepository } from '../repositories/user.repository'
 import type { CustomContext } from '../types/custom-context.type'
-import { Buffer } from 'node:buffer'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import { join } from 'node:path'
 import { InputFile } from 'grammy'
+import muhammara from 'muhammara'
 import { pdf } from 'pdf-to-img'
 import { CommandEnum } from '../enums/command.enum'
+import { PlanTypeEnum } from '../enums/plan-type.enum'
+import { LimitExceededError } from '../errors/limit-exceeded.error'
+import { UserNotFoundError } from '../errors/user-not-found.error'
 import { BaseHandler } from './base.handler'
 
 export class PdfToImagesHandler extends BaseHandler {
+  private static readonly MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB
+  private static readonly MAX_PAGES = 50
+
   constructor(private readonly userRepository: UserRepository) {
     super()
   }
@@ -24,9 +30,6 @@ export class PdfToImagesHandler extends BaseHandler {
       let outputDir: string | undefined
 
       try {
-        outputDir = await fs.mkdtemp(join(os.tmpdir(), 'pdf-studio-bot-pdf-to-images-'))
-        await fs.chmod(outputDir, 0o700)
-
         const file = await ctx.getFile()
         inputPath = await file.download()
 
@@ -34,15 +37,20 @@ export class PdfToImagesHandler extends BaseHandler {
           throw new Error('Failed to download file')
         }
 
+        await this.verifyLimits(ctx, inputPath)
+
         const document = await pdf(inputPath)
-        let pageNumber = 1
         const totalPages = document.length
 
         await ctx.reply(`🖼️ Converting ${totalPages} pages to images...`)
 
+        outputDir = await fs.mkdtemp(join(os.tmpdir(), 'pdf-studio-bot-pdf-to-images-'))
+        await fs.chmod(outputDir, 0o700)
+
+        let pageNumber = 1
         for await (const image of document) {
           const imagePath = join(outputDir, `page-${pageNumber}.png`)
-          await fs.writeFile(imagePath, Buffer.from(image))
+          await fs.writeFile(imagePath, image)
 
           const imageFile = new InputFile(imagePath, `page-${pageNumber}.png`)
 
@@ -52,9 +60,12 @@ export class PdfToImagesHandler extends BaseHandler {
           pageNumber++
         }
 
-        await this.userRepository.incrementUsage(ctx.from!.id)
+        await this.userRepository.incrementUsage(ctx.from?.id ?? 0)
       }
       catch (error) {
+        if (error instanceof LimitExceededError)
+          return
+
         this.logger.error(error)
         await ctx.reply('❌ An error occurred while converting the PDF to images.')
       }
@@ -75,5 +86,29 @@ export class PdfToImagesHandler extends BaseHandler {
   async onCommand(ctx: CustomContext): Promise<void> {
     await this.setSessionCommand(ctx)
     await ctx.reply('Please send the PDF file you want to convert to images.')
+  }
+
+  private async verifyLimits(ctx: CustomContext, path: string): Promise<void> {
+    const user = await this.userRepository.findByTelegramId(ctx.from?.id ?? 0)
+    if (!user)
+      throw new UserNotFoundError()
+    if (user.plan_type === PlanTypeEnum.Pro)
+      return
+
+    const stats = await fs.stat(path)
+    if (stats.size > PdfToImagesHandler.MAX_FILE_SIZE) {
+      await this.notifyLimitExceeded(ctx)
+      throw new LimitExceededError()
+    }
+
+    const pdfReader = muhammara.createReader(path)
+    if (pdfReader.getPagesCount() > PdfToImagesHandler.MAX_PAGES) {
+      await this.notifyLimitExceeded(ctx)
+      throw new LimitExceededError()
+    }
+  }
+
+  private async notifyLimitExceeded(ctx: CustomContext): Promise<void> {
+    await ctx.reply('⚠️ You have exceeded the limits of the free plan. You need to become pro and it costs 10 $ / month. Talk to @gabrielrufino to buy the pro plan.')
   }
 }

--- a/src/handlers/pdf-to-images.handler.ts
+++ b/src/handlers/pdf-to-images.handler.ts
@@ -3,11 +3,12 @@ import type { CustomContext } from '../types/custom-context.type'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import { join } from 'node:path'
-import { InputFile } from 'grammy'
+import { InputFile, type InputMediaPhoto } from 'grammy'
 import muhammara from 'muhammara'
 import { pdf } from 'pdf-to-img'
 import { CommandEnum } from '../enums/command.enum'
 import { PlanTypeEnum } from '../enums/plan-type.enum'
+import { InvalidFileError } from '../errors/invalid-file.error'
 import { LimitExceededError } from '../errors/limit-exceeded.error'
 import { UserNotFoundError } from '../errors/user-not-found.error'
 import { BaseHandler } from './base.handler'
@@ -47,24 +48,43 @@ export class PdfToImagesHandler extends BaseHandler {
         outputDir = await fs.mkdtemp(join(os.tmpdir(), 'pdf-studio-bot-pdf-to-images-'))
         await fs.chmod(outputDir, 0o700)
 
+        const images: string[] = []
         let pageNumber = 1
         for await (const image of document) {
           const imagePath = join(outputDir, `page-${pageNumber}.png`)
           await fs.writeFile(imagePath, image)
-
-          const imageFile = new InputFile(imagePath, `page-${pageNumber}.png`)
-
-          await ctx.replyWithPhoto(imageFile, {
-            caption: `🖼️ Page ${pageNumber} of ${totalPages}`,
-          })
+          images.push(imagePath)
           pageNumber++
+        }
+
+        const CHUNK_SIZE = 10
+        for (let i = 0; i < images.length; i += CHUNK_SIZE) {
+          const chunk = images.slice(i, i + CHUNK_SIZE)
+          if (chunk.length > 1) {
+            const mediaGroup: InputMediaPhoto[] = chunk.map((imagePath, index) => {
+              const currentPage = i + index + 1
+              return {
+                type: 'photo',
+                media: new InputFile(imagePath, `page-${currentPage}.png`),
+                caption: index === 0 ? `🖼️ Pages ${i + 1}-${i + chunk.length} of ${totalPages}` : undefined,
+              }
+            })
+            await ctx.api.sendMediaGroup(ctx.chat!.id, mediaGroup)
+          }
+          else {
+            const currentPage = i + 1
+            await ctx.replyWithPhoto(new InputFile(chunk[0], `page-${currentPage}.png`), {
+              caption: `🖼️ Page ${currentPage} of ${totalPages}`,
+            })
+          }
         }
 
         await this.userRepository.incrementUsage(ctx.from?.id ?? 0)
       }
       catch (error) {
-        if (error instanceof LimitExceededError)
+        if (error instanceof InvalidFileError || error instanceof LimitExceededError) {
           return
+        }
 
         this.logger.error(error)
         await ctx.reply('❌ An error occurred while converting the PDF to images.')

--- a/src/handlers/pdf-to-images.handler.ts
+++ b/src/handlers/pdf-to-images.handler.ts
@@ -1,0 +1,65 @@
+import type { UserRepository } from '../repositories/user.repository'
+import type { CustomContext } from '../types/custom-context.type'
+import fs from 'node:fs/promises'
+import { InputFile } from 'grammy'
+import { pdf } from 'pdf-to-img'
+import { CommandEnum } from '../enums/command.enum'
+import { BaseHandler } from './base.handler'
+
+export class PdfToImagesHandler extends BaseHandler {
+  constructor(private readonly userRepository: UserRepository) {
+    super()
+  }
+
+  readonly command = CommandEnum.PdfToImages
+  readonly description = '🖼️ Convert PDF pages to images'
+  readonly events = {
+    'msg:document': async (ctx: CustomContext) => {
+      await this.validatePDF(ctx)
+
+      let inputPath: string | undefined
+
+      try {
+        const file = await ctx.getFile()
+        inputPath = await file.download()
+
+        if (!inputPath) {
+          throw new Error('Failed to download file')
+        }
+
+        const document = await pdf(inputPath)
+        let pageNumber = 1
+        const totalPages = document.getPageCount()
+
+        await ctx.reply(`🖼️ Converting ${totalPages} pages to images...`)
+
+        for await (const image of document) {
+          const imageFile = new InputFile(image, `page-${pageNumber}.png`)
+
+          await ctx.replyWithPhoto(imageFile, {
+            caption: `🖼️ Page ${pageNumber} of ${totalPages}`,
+          })
+          pageNumber++
+        }
+
+        await this.userRepository.incrementUsage(ctx.from!.id)
+      }
+      catch (error) {
+        this.logger.error(error)
+        await ctx.reply('❌ An error occurred while converting the PDF to images.')
+      }
+      finally {
+        if (inputPath) {
+          await fs.rm(inputPath, { force: true }).catch(error =>
+            this.logger.error({ error, path: inputPath }, 'Failed to remove input file.'))
+        }
+        await this.resetSession(ctx)
+      }
+    },
+  }
+
+  async onCommand(ctx: CustomContext): Promise<void> {
+    await this.setSessionCommand(ctx)
+    await ctx.reply('Please send the PDF file you want to convert to images.')
+  }
+}

--- a/src/handlers/pdf-to-images.handler.ts
+++ b/src/handlers/pdf-to-images.handler.ts
@@ -1,9 +1,10 @@
+import type { InputMediaPhoto } from 'grammy/types'
 import type { UserRepository } from '../repositories/user.repository'
 import type { CustomContext } from '../types/custom-context.type'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import { join } from 'node:path'
-import { InputFile, type InputMediaPhoto } from 'grammy'
+import { InputFile } from 'grammy'
 import muhammara from 'muhammara'
 import { pdf } from 'pdf-to-img'
 import { CommandEnum } from '../enums/command.enum'
@@ -25,12 +26,11 @@ export class PdfToImagesHandler extends BaseHandler {
   readonly description = '🖼️ Convert PDF pages to images'
   readonly events = {
     'msg:document': async (ctx: CustomContext) => {
-      await this.validatePDF(ctx)
-
       let inputPath: string | undefined
       let outputDir: string | undefined
 
       try {
+        await this.validatePDF(ctx)
         const file = await ctx.getFile()
         inputPath = await file.download()
 


### PR DESCRIPTION
This PR introduces a new operation to the PDF Studio Bot that allows users to convert each page of a PDF document into a separate image.

Key changes:
- New `PdfToImagesHandler` implemented using the `pdf-to-img` library.
- Images are sent back to the user as photos with appropriate captions.
- Integrated usage tracking and limit validation.
- Robust cleanup logic to remove temporary files after processing.
- Comprehensive unit tests covering success and failure scenarios.
- Used `pdf-to-img` which relies on `pdfjs-dist`, avoiding complex native builds required by other libraries like `canvas`.

---
*PR created automatically by Jules for task [3908448121444501952](https://jules.google.com/task/3908448121444501952) started by @gabrielrufino*