### PR TITLE
Implement fallback for unexpected messages and unknown commands

### DIFF
--- a/src/handlers/join.handler.ts
+++ b/src/handlers/join.handler.ts
@@ -45,7 +45,10 @@ export class JoinHandler extends BaseHandler {
 
       if (text === 'done') {
         await this.joinPDFs(ctx)
+        return
       }
+
+      await ctx.reply('⚠️ Please send more PDF files or type "done" to merge them.')
     },
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import { logger } from './config/logger'
 import { InvalidFileError } from './errors/invalid-file.error'
 import { SessionValidationError } from './errors/session-validation.error'
 import { handlers } from './handlers'
+import { HelpMessage } from './messages/help.message'
+import { UnknownMessage } from './messages/unknown.message'
 import { usageLimitMiddleware } from './middlewares/usage-limit.middleware'
 import { repositories } from './repositories'
 
@@ -28,7 +30,7 @@ async function main() {
 
   const events = new Set(handlers.flatMap(handler => Object.keys(handler.events) as FilterQuery[]))
   for (const event of events) {
-    bot.on(event, async (ctx) => {
+    bot.on(event, async (ctx, next) => {
       const userId = ctx.from?.id || ctx.chat?.id
       if (!userId) {
         return
@@ -39,7 +41,7 @@ async function main() {
       const eventHandler = handler?.events[event]
 
       if (!handler || !eventHandler) {
-        return
+        return next()
       }
 
       try {
@@ -57,6 +59,12 @@ async function main() {
   await bot.api.setMyCommands(
     handlers.map(h => ({ command: h.command, description: h.description })),
   )
+
+  bot.on('message', async (ctx) => {
+    await ctx.reply(
+      `${new UnknownMessage().build()}\n\n${new HelpMessage(handlers).build()}`,
+    )
+  })
 
   const stop = async () => {
     logger.info('Shutting down gracefully...')

--- a/src/messages/unknown.message.spec.ts
+++ b/src/messages/unknown.message.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { UnknownMessage } from './unknown.message'
+
+describe(UnknownMessage.name, () => {
+  it('should return a "not understood" message', () => {
+    const result = new UnknownMessage().build()
+    expect(result).toBe("⚠️ I'm sorry, I didn't understand that. Please check the available commands below:")
+  })
+
+  it('should return a string', () => {
+    expect(new UnknownMessage().build()).toBeTypeOf('string')
+  })
+})

--- a/src/messages/unknown.message.spec.ts
+++ b/src/messages/unknown.message.spec.ts
@@ -4,7 +4,7 @@ import { UnknownMessage } from './unknown.message'
 describe(UnknownMessage.name, () => {
   it('should return a "not understood" message', () => {
     const result = new UnknownMessage().build()
-    expect(result).toBe("⚠️ I'm sorry, I didn't understand that. Please check the available commands below:")
+    expect(result).toBe('⚠️ I\'m sorry, I didn\'t understand that. Please check the available commands below:')
   })
 
   it('should return a string', () => {

--- a/src/messages/unknown.message.ts
+++ b/src/messages/unknown.message.ts
@@ -1,0 +1,7 @@
+import type { Message } from '../interfaces/message'
+
+export class UnknownMessage implements Message {
+  public build() {
+    return "⚠️ I'm sorry, I didn't understand that. Please check the available commands below:"
+  }
+}

--- a/src/messages/unknown.message.ts
+++ b/src/messages/unknown.message.ts
@@ -2,6 +2,6 @@ import type { Message } from '../interfaces/message'
 
 export class UnknownMessage implements Message {
   public build() {
-    return "⚠️ I'm sorry, I didn't understand that. Please check the available commands below:"
+    return '⚠️ I\'m sorry, I didn\'t understand that. Please check the available commands below:'
   }
 }


### PR DESCRIPTION
This change implements a way to respond to unexpected messages and unknown commands. 
It introduces a global catch-all handler at the end of the bot's middleware chain that replies with an "I didn't understand" message followed by the list of available commands. 
Additionally, the event dispatcher was updated to call `next()` when no specific session handler matches, allowing those messages to reach the global fallback. 
The `JoinHandler` was also improved to provide session-specific feedback when the user sends unexpected text while joining PDFs.

---
*PR created automatically by Jules for task [7422646646505458896](https://jules.google.com/task/7422646646505458896) started by @gabrielrufino*