### PR TITLE
🧪 test: add coverage for LanguageHandler

### DIFF
--- a/src/handlers/language.handler.spec.ts
+++ b/src/handlers/language.handler.spec.ts
@@ -6,6 +6,14 @@ import { CommandEnum } from '../enums/command.enum'
 import { LanguageEnum } from '../enums/language.enum'
 import { LanguageHandler } from './language.handler'
 
+vi.mock('../config/database', () => ({
+  database: {
+    collection: vi.fn(),
+  },
+  mongoClient: {},
+}))
+vi.mock('../repositories')
+
 describe(LanguageHandler.name, () => {
   let handler: LanguageHandler
   let userRepository: UserRepository

--- a/src/handlers/language.handler.spec.ts
+++ b/src/handlers/language.handler.spec.ts
@@ -46,7 +46,7 @@ describe(LanguageHandler.name, () => {
 
   describe(LanguageHandler.prototype.onCommand.name, () => {
     it('should set session command and reply with language options', async () => {
-      const ctx: any = {
+      const ctx = {
         t: (key: string) => key,
         session: {
           command: null,
@@ -75,7 +75,7 @@ describe(LanguageHandler.name, () => {
 
   describe('events.callback_query', () => {
     it('should do nothing if data is missing', async () => {
-      const ctx: any = {
+      const ctx = {
         callbackQuery: {},
       } as unknown as CustomContext
 
@@ -85,7 +85,7 @@ describe(LanguageHandler.name, () => {
     })
 
     it('should do nothing if data is not a valid LanguageEnum', async () => {
-      const ctx: any = {
+      const ctx = {
         callbackQuery: { data: 'invalid' },
       } as unknown as CustomContext
 
@@ -99,9 +99,9 @@ describe(LanguageHandler.name, () => {
         _id: 'user_123',
         language: LanguageEnum.English,
       }
-      vi.spyOn(userRepository, 'findByTelegramId').mockResolvedValue(mockUser as any)
+      vi.mocked(userRepository.findByTelegramId).mockResolvedValue(mockUser as any)
 
-      const ctx: any = {
+      const ctx = {
         callbackQuery: { data: LanguageEnum.Spanish },
         from: { id: 12345 },
         session: { language: LanguageEnum.English, command: CommandEnum.Language, params: {} },
@@ -117,9 +117,9 @@ describe(LanguageHandler.name, () => {
     })
 
     it('should set session language, send responses and reset session', async () => {
-      vi.spyOn(userRepository, 'findByTelegramId').mockResolvedValue(null)
+      vi.mocked(userRepository.findByTelegramId).mockResolvedValue(null)
 
-      const ctx: any = {
+      const ctx = {
         callbackQuery: { data: LanguageEnum.Portuguese },
         from: { id: 12345 },
         session: { language: LanguageEnum.English, command: CommandEnum.Language, params: { foo: 'bar' } },

--- a/src/handlers/language.handler.spec.ts
+++ b/src/handlers/language.handler.spec.ts
@@ -1,0 +1,132 @@
+import type { UserRepository } from '../repositories/user.repository'
+import type { CustomContext } from '../types/custom-context.type'
+import { InlineKeyboard } from 'grammy'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CommandEnum } from '../enums/command.enum'
+import { LanguageEnum } from '../enums/language.enum'
+import { LanguageHandler } from './language.handler'
+
+describe(LanguageHandler.name, () => {
+  let handler: LanguageHandler
+  let userRepository: UserRepository
+
+  beforeEach(() => {
+    userRepository = {
+      create: vi.fn(),
+      findByTelegramId: vi.fn().mockResolvedValue(null),
+      updateById: vi.fn(),
+    } as unknown as UserRepository
+
+    handler = new LanguageHandler(userRepository)
+  })
+
+  it('should be defined', () => {
+    expect(handler).toBeDefined()
+  })
+
+  it('should have the correct command', () => {
+    expect(handler.command).toBe(CommandEnum.Language)
+  })
+
+  it('should have the correct description', () => {
+    expect(handler.description).toBe('🌐 Change your language')
+  })
+
+  it('should have correct hasUsageLimits value', () => {
+    expect(handler.hasUsageLimits).toBe(false)
+  })
+
+  describe(LanguageHandler.prototype.onCommand.name, () => {
+    it('should set session command and reply with language options', async () => {
+      const ctx: any = {
+        t: (key: string) => key,
+        session: {
+          command: null,
+          params: null,
+        },
+        reply: vi.fn(),
+      } as unknown as CustomContext
+
+      await handler.onCommand(ctx)
+
+      expect(ctx.session.command).toBe(CommandEnum.Language)
+      expect(ctx.reply).toHaveBeenCalledTimes(1)
+
+      const expectedKeyboard = new InlineKeyboard()
+        .text('English', LanguageEnum.English)
+        .row()
+        .text('Português', LanguageEnum.Portuguese)
+        .row()
+        .text('Español', LanguageEnum.Spanish)
+
+      expect(ctx.reply).toHaveBeenCalledWith('language_choose', {
+        reply_markup: expectedKeyboard,
+      })
+    })
+  })
+
+  describe('events.callback_query', () => {
+    it('should do nothing if data is missing', async () => {
+      const ctx: any = {
+        callbackQuery: {},
+      } as unknown as CustomContext
+
+      await handler.events.callback_query(ctx)
+
+      expect(userRepository.findByTelegramId).not.toHaveBeenCalled()
+    })
+
+    it('should do nothing if data is not a valid LanguageEnum', async () => {
+      const ctx: any = {
+        callbackQuery: { data: 'invalid' },
+      } as unknown as CustomContext
+
+      await handler.events.callback_query(ctx)
+
+      expect(userRepository.findByTelegramId).not.toHaveBeenCalled()
+    })
+
+    it('should update user language if user exists', async () => {
+      const mockUser = {
+        _id: 'user_123',
+        language: LanguageEnum.English,
+      }
+      vi.spyOn(userRepository, 'findByTelegramId').mockResolvedValue(mockUser as any)
+
+      const ctx: any = {
+        callbackQuery: { data: LanguageEnum.Spanish },
+        from: { id: 12345 },
+        session: { language: LanguageEnum.English, command: CommandEnum.Language, params: {} },
+        answerCallbackQuery: vi.fn(),
+        editMessageText: vi.fn(),
+      } as unknown as CustomContext
+
+      await handler.events.callback_query(ctx)
+
+      expect(userRepository.findByTelegramId).toHaveBeenCalledWith(12345)
+      expect(mockUser.language).toBe(LanguageEnum.Spanish)
+      expect(userRepository.updateById).toHaveBeenCalledWith('user_123', mockUser)
+    })
+
+    it('should set session language, send responses and reset session', async () => {
+      vi.spyOn(userRepository, 'findByTelegramId').mockResolvedValue(null)
+
+      const ctx: any = {
+        callbackQuery: { data: LanguageEnum.Portuguese },
+        from: { id: 12345 },
+        session: { language: LanguageEnum.English, command: CommandEnum.Language, params: { foo: 'bar' } },
+        answerCallbackQuery: vi.fn(),
+        editMessageText: vi.fn(),
+      } as unknown as CustomContext
+
+      await handler.events.callback_query(ctx)
+
+      expect(ctx.session.language).toBe(LanguageEnum.Portuguese)
+
+      expect(ctx.answerCallbackQuery).toHaveBeenCalledTimes(1)
+      expect(ctx.editMessageText).toHaveBeenCalledTimes(1)
+      expect(ctx.session.command).toBeNull()
+      expect(ctx.session.params).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
🎯 **What:** The testing gap for `LanguageHandler` was addressed by writing a new unit test suite using Vitest.

📊 **Coverage:** The new tests cover:
- Basic handler properties (`command`, `description`, `hasUsageLimits`).
- The `onCommand` method, verifying that it correctly sets the session command and returns the language-switching inline keyboard.
- The `events.callback_query` logic, covering:
  - Missing or invalid language callback data.
  - Successfully updating an existing user's language via the repository.
  - Correctly updating session state, answering/editing messages, and cleaning up the session.

✨ **Result:** Test coverage for `src/handlers/language.handler.ts` is complete, and the overall reliability of the i18n logic is secured against future regressions.

---
*PR created automatically by Jules for task [10460517647083699238](https://jules.google.com/task/10460517647083699238) started by @gabrielrufino*