### PR TITLE
🧪 [test] add i18n middleware unit tests

### DIFF
--- a/src/middlewares/i18n.middleware.spec.ts
+++ b/src/middlewares/i18n.middleware.spec.ts
@@ -30,7 +30,7 @@ describe(i18nMiddleware.name, () => {
 
     expect(userRepository.findByTelegramId).not.toHaveBeenCalled()
     expect(ctx.session.language).toBe(LanguageEnum.Spanish)
-    expect(ctx.t).toBeDefined()
+    expect(ctx.t('operation_help')).toBe(locales.es.operation_help)
     expect(next).toHaveBeenCalled()
   })
 
@@ -43,6 +43,7 @@ describe(i18nMiddleware.name, () => {
 
     expect(userRepository.findByTelegramId).toHaveBeenCalledWith(12345)
     expect(ctx.session.language).toBe(LanguageEnum.Portuguese)
+    expect(ctx.t('operation_help')).toBe(locales.pt.operation_help)
     expect(next).toHaveBeenCalled()
   })
 
@@ -55,6 +56,7 @@ describe(i18nMiddleware.name, () => {
     await i18nMiddleware(ctx, next)
 
     expect(ctx.session.language).toBe(LanguageEnum.Spanish)
+    expect(ctx.t('operation_help')).toBe(locales.es.operation_help)
     expect(next).toHaveBeenCalled()
   })
 
@@ -67,6 +69,7 @@ describe(i18nMiddleware.name, () => {
     await i18nMiddleware(ctx, next)
 
     expect(ctx.session.language).toBe(LanguageEnum.English)
+    expect(ctx.t('operation_help')).toBe(locales.en.operation_help)
     expect(next).toHaveBeenCalled()
   })
 
@@ -76,6 +79,7 @@ describe(i18nMiddleware.name, () => {
     await i18nMiddleware(ctx, next)
 
     expect(ctx.session.language).toBe(LanguageEnum.English)
+    expect(ctx.t('operation_help')).toBe(locales.en.operation_help)
     expect(next).toHaveBeenCalled()
   })
 

--- a/src/middlewares/i18n.middleware.spec.ts
+++ b/src/middlewares/i18n.middleware.spec.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { LanguageEnum } from '../enums/language.enum'
+import { userRepository } from '../repositories'
+import { i18nMiddleware, locales } from './i18n.middleware'
+
+vi.mock('../repositories', () => ({
+  userRepository: {
+    findByTelegramId: vi.fn(),
+  },
+}))
+
+describe(i18nMiddleware.name, () => {
+  let next: any
+  let ctx: any
+
+  beforeEach(() => {
+    next = vi.fn()
+    ctx = {
+      from: { id: 12345, language_code: undefined },
+      session: { language: undefined },
+      t: undefined,
+    }
+    vi.clearAllMocks()
+  })
+
+  it('should use language from session if present', async () => {
+    ctx.session.language = LanguageEnum.Spanish
+
+    await i18nMiddleware(ctx, next)
+
+    expect(userRepository.findByTelegramId).not.toHaveBeenCalled()
+    expect(ctx.session.language).toBe(LanguageEnum.Spanish)
+    expect(ctx.t).toBeDefined()
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should use language from user database if session is empty', async () => {
+    vi.mocked(userRepository.findByTelegramId).mockResolvedValueOnce({
+      language: LanguageEnum.Portuguese,
+    } as any)
+
+    await i18nMiddleware(ctx, next)
+
+    expect(userRepository.findByTelegramId).toHaveBeenCalledWith(12345)
+    expect(ctx.session.language).toBe(LanguageEnum.Portuguese)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should use language from context if user has no language in database and language code is supported', async () => {
+    vi.mocked(userRepository.findByTelegramId).mockResolvedValueOnce({
+      language: undefined,
+    } as any)
+    ctx.from.language_code = 'es'
+
+    await i18nMiddleware(ctx, next)
+
+    expect(ctx.session.language).toBe(LanguageEnum.Spanish)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should fallback to english if language from context is not supported', async () => {
+    vi.mocked(userRepository.findByTelegramId).mockResolvedValueOnce({
+      language: undefined,
+    } as any)
+    ctx.from.language_code = 'fr' // Not supported
+
+    await i18nMiddleware(ctx, next)
+
+    expect(ctx.session.language).toBe(LanguageEnum.English)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should fallback to english if database user is not found and no context language code', async () => {
+    vi.mocked(userRepository.findByTelegramId).mockResolvedValueOnce(null)
+
+    await i18nMiddleware(ctx, next)
+
+    expect(ctx.session.language).toBe(LanguageEnum.English)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should fallback to english translations if from is missing', async () => {
+    ctx.from = undefined
+
+    await i18nMiddleware(ctx, next)
+
+    expect(ctx.session.language).toBeUndefined()
+    expect(ctx.t('operation_help')).toBe(locales.en.operation_help)
+    expect(next).toHaveBeenCalled()
+  })
+
+  describe('ctx.t translation function', () => {
+    it('should translate known keys using the selected language', async () => {
+      ctx.session.language = LanguageEnum.English
+      await i18nMiddleware(ctx, next)
+
+      expect(ctx.t('operation_help')).toBe(locales.en.operation_help)
+    })
+
+    it('should return the key if translation is not found', async () => {
+      ctx.session.language = LanguageEnum.English
+      await i18nMiddleware(ctx, next)
+
+      expect(ctx.t('unknown_translation_key')).toBe('unknown_translation_key')
+    })
+
+    it('should fallback to english translations if language is somehow unsupported string', async () => {
+      ctx.session.language = 'unsupported' as any
+      await i18nMiddleware(ctx, next)
+
+      expect(ctx.t('operation_help')).toBe(locales.en.operation_help)
+    })
+  })
+})


### PR DESCRIPTION
🎯 **What:** Adds missing unit tests for the `i18nMiddleware` in `src/middlewares/i18n.middleware.spec.ts`.

📊 **Coverage:**
- Language resolution priority (Session > Database > Context > Fallback).
- Database querying behavior (only fetched if session is empty).
- Fallbacks for unsupported Telegram client languages and missing user objects (`ctx.from = undefined`).
- Translation function `ctx.t` testing for both known keys, unknown keys, and unexpected language values.

✨ **Result:** Enhanced test coverage and ensured reliability of the app's internationalization handling. 9 new test cases written; 200/200 total project tests are now passing successfully.

---
*PR created automatically by Jules for task [11755365134964637111](https://jules.google.com/task/11755365134964637111) started by @gabrielrufino*