### PR TITLE
🔒 fix: mask passwords during removepassword command

### DIFF
--- a/src/middlewares/message-recorder.middleware.spec.ts
+++ b/src/middlewares/message-recorder.middleware.spec.ts
@@ -42,6 +42,19 @@ describe(messageRecorderMiddleware.name, () => {
     expect(next).toHaveBeenCalled()
   })
 
+  it('should mask password text if command is RemovePassword', async () => {
+    ctx.session.command = CommandEnum.RemovePassword
+    ctx.message.text = 'secret123'
+
+    await messageRecorderMiddleware(ctx, next)
+
+    expect(messageRepository.create).toHaveBeenCalledWith(expect.objectContaining({
+      text: '***',
+      telegram_user: ctx.from,
+    }))
+    expect(next).toHaveBeenCalled()
+  })
+
   it('should handle missing message text', async () => {
     ctx.message.text = undefined
 

--- a/src/middlewares/message-recorder.middleware.ts
+++ b/src/middlewares/message-recorder.middleware.ts
@@ -6,7 +6,7 @@ import { messageRepository } from '../repositories'
 
 export async function messageRecorderMiddleware(ctx: CustomContext, next: NextFunction) {
   if (ctx.message) {
-    const isPassword = ctx.session.command === CommandEnum.PutPassword
+    const isPassword = ctx.session.command === CommandEnum.PutPassword || ctx.session.command === CommandEnum.RemovePassword
 
     const message = new MessageEntity({
       text: isPassword ? '***' : (ctx.message.text || ''),

--- a/src/middlewares/message-recorder.middleware.ts
+++ b/src/middlewares/message-recorder.middleware.ts
@@ -6,7 +6,8 @@ import { messageRepository } from '../repositories'
 
 export async function messageRecorderMiddleware(ctx: CustomContext, next: NextFunction) {
   if (ctx.message) {
-    const isPassword = ctx.session.command === CommandEnum.PutPassword || ctx.session.command === CommandEnum.RemovePassword
+    const isPassword = [CommandEnum.PutPassword, CommandEnum.RemovePassword]
+      .includes(ctx.session?.command as CommandEnum)
 
     const message = new MessageEntity({
       text: isPassword ? '***' : (ctx.message.text || ''),


### PR DESCRIPTION
🎯 **What:** Fixed a vulnerability where plain text passwords provided during the `/removepassword` command were being saved in cleartext to the database.
⚠️ **Risk:** Storing cleartext passwords exposes users' sensitive information and violates security best practices, potentially compromising the user's PDF security if the database were ever accessed.
🛡️ **Solution:** Updated the boolean `isPassword` logic in `src/middlewares/message-recorder.middleware.ts` to check against `CommandEnum.RemovePassword` in addition to `CommandEnum.PutPassword`. Added a test case in `src/middlewares/message-recorder.middleware.spec.ts` to assert that input strings are correctly masked to `***` for the `RemovePassword` command.

---
*PR created automatically by Jules for task [14154483541992682207](https://jules.google.com/task/14154483541992682207) started by @gabrielrufino*