### PR TITLE
🧹 Fix empty catch block in remove-password handler

### DIFF
--- a/src/handlers/remove-password.handler.ts
+++ b/src/handlers/remove-password.handler.ts
@@ -17,7 +17,9 @@ export class RemovePasswordHandler extends PasswordBaseHandler {
       try {
         pdfWriter.end()
       }
-      catch { }
+      catch (cleanupError) {
+        this.logger.error({ error: cleanupError }, 'Failed to close PDF writer during cleanup.')
+      }
       throw error
     }
   }


### PR DESCRIPTION
🎯 **What:** Modified the error handling logic in `src/handlers/remove-password.handler.ts` to log any failure that occurs while executing `pdfWriter.end()` in the catch block rather than silently swallowing it.

💡 **Why:** Silently swallowing errors with an empty catch block obfuscates what happened during cleanup, making the system difficult to maintain and troubleshoot. Logging the error improves observability and debugging capability without altering behavior.

✅ **Verification:** Verified that linting (`npm run lint`) and all tests (`npm run test`) pass. Ensured that `this.logger` is appropriately available from `PasswordBaseHandler`, the parent class.

✨ **Result:** Improved maintainability through better error logging visibility during PDF writer cleanup failures.

---
*PR created automatically by Jules for task [15798044288538043591](https://jules.google.com/task/15798044288538043591) started by @gabrielrufino*