### PR TITLE
🧪 test: improve re-engagement job error handling coverage

### DIFF
--- a/src/jobs/reengagement.job.spec.ts
+++ b/src/jobs/reengagement.job.spec.ts
@@ -2,6 +2,7 @@ import type { UserEntity } from '../entities/user.entity'
 import cron from 'node-cron'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { bot } from '../config/bot'
+import { logger } from '../config/logger'
 import { LanguageEnum } from '../enums/language.enum'
 import { locales } from '../middlewares/i18n.middleware'
 import { userRepository } from '../repositories'
@@ -20,6 +21,13 @@ vi.mock('../config/bot', () => ({
     api: {
       sendMessage: vi.fn(),
     },
+  },
+}))
+
+vi.mock('../config/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
   },
 }))
 
@@ -69,5 +77,41 @@ describe('reengagementJob', () => {
     expect(bot.api.sendMessage).toHaveBeenCalledTimes(2)
     expect(bot.api.sendMessage).toHaveBeenCalledWith(123, locales.en.reengagement_message, { parse_mode: 'HTML' })
     expect(bot.api.sendMessage).toHaveBeenCalledWith(456, locales.pt.reengagement_message, { parse_mode: 'HTML' })
+  })
+
+  it('should log an error and continue if sending a message fails', async () => {
+    const error = new Error('Telegram API Error')
+    vi.mocked(bot.api.sendMessage).mockRejectedValueOnce(error).mockResolvedValueOnce({} as any)
+
+    const inactiveUsers: Partial<UserEntity>[] = [
+      {
+        _id: 'user1' as any,
+        telegram_user: { id: 123 } as any,
+        language: LanguageEnum.English,
+      },
+      {
+        _id: 'user2' as any,
+        telegram_user: { id: 456 } as any,
+        language: LanguageEnum.Portuguese,
+      },
+    ]
+
+    vi.mocked(userRepository.findInactiveUsers).mockResolvedValue({
+      async *[Symbol.asyncIterator]() {
+        for (const user of inactiveUsers) {
+          yield user
+        }
+      },
+    } as any)
+
+    initReengagementJob()
+    const callback = (globalThis as any).cronCallback
+    await callback()
+
+    expect(bot.api.sendMessage).toHaveBeenCalledTimes(2)
+    expect(logger.error).toHaveBeenCalledWith(
+      { error, userId: 123 },
+      'Failed to send re-engagement message',
+    )
   })
 })

--- a/src/jobs/reengagement.job.spec.ts
+++ b/src/jobs/reengagement.job.spec.ts
@@ -109,6 +109,9 @@ describe('reengagementJob', () => {
     await callback()
 
     expect(bot.api.sendMessage).toHaveBeenCalledTimes(2)
+    expect(bot.api.sendMessage).toHaveBeenNthCalledWith(1, 123, locales.en.reengagement_message, { parse_mode: 'HTML' })
+    expect(bot.api.sendMessage).toHaveBeenNthCalledWith(2, 456, locales.pt.reengagement_message, { parse_mode: 'HTML' })
+    expect(logger.error).toHaveBeenCalledTimes(1)
     expect(logger.error).toHaveBeenCalledWith(
       { error, userId: 123 },
       'Failed to send re-engagement message',


### PR DESCRIPTION
🎯 **What:** This PR addresses a testing gap in the re-engagement background job where failures to send messages (e.g., due to Telegram API issues or rate limits) were not explicitly tested. 
📊 **Coverage:** A new test case `it('should log an error and continue if sending a message fails')` is added. It stubs the Telegram API client to simulate a failure on the first message sent, but a success on the second one.
✨ **Result:** Validates that the loop continues safely rather than crashing the background worker, and ensures full logging via `logger.error` occurs with proper contextual inputs, making the test suite and execution behavior more reliable.

---
*PR created automatically by Jules for task [17470422462095017046](https://jules.google.com/task/17470422462095017046) started by @gabrielrufino*