### PR TITLE
🧪 Extract UserNotFoundError to dedicated test file

### DIFF
--- a/src/errors/errors.spec.ts
+++ b/src/errors/errors.spec.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest'
 import { InvalidFileError } from './invalid-file.error'
 import { LimitExceededError } from './limit-exceeded.error'
 import { SessionValidationError } from './session-validation.error'
-import { UserNotFoundError } from './user-not-found.error'
 
 describe('custom errors', () => {
   describe(InvalidFileError.name, () => {
@@ -28,15 +27,6 @@ describe('custom errors', () => {
       const error = new SessionValidationError()
       expect(error.message).toBe('An error occurred. Please start the command again.')
       expect(error.name).toBe('SessionValidationError')
-      expect(error).toBeInstanceOf(Error)
-    })
-  })
-
-  describe(UserNotFoundError.name, () => {
-    it('should have correct message and name', () => {
-      const error = new UserNotFoundError()
-      expect(error.message).toBe('User not found.')
-      expect(error.name).toBe('UserNotFoundError')
       expect(error).toBeInstanceOf(Error)
     })
   })

--- a/src/errors/user-not-found.error.spec.ts
+++ b/src/errors/user-not-found.error.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import { UserNotFoundError } from './user-not-found.error'
+
+describe('userNotFoundError', () => {
+  it('should have correct message and name', () => {
+    const error = new UserNotFoundError()
+    expect(error.message).toBe('User not found.')
+    expect(error.name).toBe('UserNotFoundError')
+    expect(error).toBeInstanceOf(Error)
+  })
+})

--- a/src/errors/user-not-found.error.spec.ts
+++ b/src/errors/user-not-found.error.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { UserNotFoundError } from './user-not-found.error'
 
-describe('userNotFoundError', () => {
+describe(UserNotFoundError.name, () => {
   it('should have correct message and name', () => {
     const error = new UserNotFoundError()
     expect(error.message).toBe('User not found.')


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Extracted `UserNotFoundError` tests from a generic `errors.spec.ts` file to its own dedicated file `user-not-found.error.spec.ts` to follow the project convention of having individual spec files for each module.

📊 **Coverage:** What scenarios are now tested
The correct error message ('User not found.'), name ('UserNotFoundError'), and inheritance logic (`instanceof Error`) are now covered in the isolated test file.

✨ **Result:** The improvement in test coverage
Maintains 100% test coverage for the error while improving test file organization and separation of concerns.

---
*PR created automatically by Jules for task [3764327101394780422](https://jules.google.com/task/3764327101394780422) started by @gabrielrufino*