### PR TITLE
🧹 refactor: deduplicate `notifyLimitExceeded` to BaseHandler

### DIFF
--- a/src/handlers/base.handler.ts
+++ b/src/handlers/base.handler.ts
@@ -45,6 +45,10 @@ export abstract class BaseHandler {
     ctx.session.params = null
   }
 
+  protected async notifyLimitExceeded(ctx: CustomContext): Promise<void> {
+    await ctx.reply(ctx.t('free_limit_reached'))
+  }
+
   private async removeTemporaryFiles(ctx: CustomContext) {
     const params = ctx.session.params
 

--- a/src/handlers/pdf-to-images.handler.ts
+++ b/src/handlers/pdf-to-images.handler.ts
@@ -128,8 +128,4 @@ export class PdfToImagesHandler extends BaseHandler {
     await this.setSessionCommand(ctx)
     await ctx.reply(ctx.t('pdftoimages_send_file'))
   }
-
-  private async notifyLimitExceeded(ctx: CustomContext): Promise<void> {
-    await ctx.reply(ctx.t('free_limit_reached'))
-  }
 }

--- a/src/handlers/split.handler.ts
+++ b/src/handlers/split.handler.ts
@@ -104,8 +104,4 @@ export class SplitHandler extends BaseHandler {
     await this.setSessionCommand(ctx)
     await ctx.reply(ctx.t('split_send_file'))
   }
-
-  private async notifyLimitExceeded(ctx: CustomContext): Promise<void> {
-    await ctx.reply(ctx.t('free_limit_reached'))
-  }
 }

--- a/src/handlers/summary.handler.ts
+++ b/src/handlers/summary.handler.ts
@@ -96,10 +96,6 @@ export class SummaryHandler extends BaseHandler {
     }
   }
 
-  private async notifyLimitExceeded(ctx: CustomContext): Promise<void> {
-    await ctx.reply(ctx.t('free_limit_reached'))
-  }
-
   private async performSummarization(path: string, prompt: string, onUploadComplete: (fileName: string) => void): Promise<string> {
     const uploadedFile = await this.ai.files.upload({
       file: path,


### PR DESCRIPTION
🎯 **What:** The `notifyLimitExceeded` method was duplicated across `SummaryHandler`, `SplitHandler`, and `PdfToImagesHandler`. It has been extracted and moved to their shared parent class, `BaseHandler`.

💡 **Why:** This refactoring eliminates code duplication, strictly adhering to the DRY principle. By keeping a single source of truth for the `free_limit_reached` translation response, it becomes easier to update or maintain this behavior in the future without hunting down duplicates.

✅ **Verification:** All tests passed perfectly without any need for changes, indicating that the handlers still function exactly as expected. The test suite correctly validated that no functionality or context variables were compromised in the process.

✨ **Result:** The code is cleaner, shorter, more centralized, and easier to maintain. Code duplication has been successfully resolved while preserving all logic and behavior.

---
*PR created automatically by Jules for task [10978281365982510591](https://jules.google.com/task/10978281365982510591) started by @gabrielrufino*