### PR TITLE
feat: add 3-day pro trial

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,19 @@
+1. Add `ProTrial = 'pro_trial'` to `PlanTypeEnum` in `src/enums/plan-type.enum.ts`.
+2. Update `src/middlewares/usage-limit.middleware.ts`:
+    * Add `[PlanTypeEnum.ProTrial]: 50` limit (or whatever is appropriate, matching Pro).
+    * Ensure if `user.plan_type === PlanTypeEnum.ProTrial` and it has been more than 3 days since `plan_started_at`, the user is reverted to `PlanTypeEnum.Free`.
+    * Use Pro limit reached translation for `ProTrial`.
+3. Create trial initiation logic in `src/handlers/pro.handler.ts`:
+    * Under `/pro` command, add an option for a 3-day trial if they haven't used it before. Alternatively, update `onCommand` to present an inline keyboard with options: "Subscribe" and "Start 3-Day Free Trial". Wait, let me check what the exact requirement is. The prompt says "Implemente um trial de 3 dias do Pro".
+    * It might be better to just show a button or allow trial. Let's add a `Start Trial` inline button in `/pro`.
+    * How to track if they used the trial? We could add a field to `UserEntity` like `has_used_trial: boolean = false`, or just assume if they are `Free` they can start a trial. Let's add `has_used_trial` field.
+4. Update `src/entities/user.entity.ts`:
+    * Add `has_used_trial: boolean = false`.
+5. Update `src/repositories/user.repository.ts` schema to include `has_used_trial: { bsonType: 'bool' }`.
+6. Update `/pro` command logic:
+    * If `user.plan_type === PlanTypeEnum.ProTrial`, show a message that they are currently on trial.
+    * If `!user.has_used_trial`, show a button for 3-day trial.
+7. Update `src/locales/en.json`, `es.json`, `pt.json` to include translation for "pro_trial_start", "pro_trial_active", "pro_trial_started".
+8. Write/update tests for `pro.handler.spec.ts` and `usage-limit.middleware.spec.ts`.
+9. Complete pre-commit step.
+10. Submit.

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -21,5 +21,7 @@ export class UserEntity extends BaseEntity {
 
   last_usage_date?: string = undefined
 
+  has_used_trial: boolean = false
+
   language: LanguageEnum = LanguageEnum.English
 }

--- a/src/enums/plan-type.enum.ts
+++ b/src/enums/plan-type.enum.ts
@@ -1,4 +1,5 @@
 export enum PlanTypeEnum {
   Free = 'free',
   Pro = 'pro',
+  ProTrial = 'pro_trial',
 }

--- a/src/handlers/pro.handler.spec.ts
+++ b/src/handlers/pro.handler.spec.ts
@@ -194,7 +194,7 @@ describe(ProHandler.name, () => {
           callbackQuery: { data: 'pro_start_trial' },
         })
 
-        await handler.events['callback_query'](ctx)
+        await handler.events.callback_query(ctx)
 
         expect(userRepository.updateById).toHaveBeenCalledWith('user-id', {
           plan_type: PlanTypeEnum.ProTrial,
@@ -214,7 +214,7 @@ describe(ProHandler.name, () => {
           callbackQuery: { data: 'pro_start_trial' },
         })
 
-        await handler.events['callback_query'](ctx)
+        await handler.events.callback_query(ctx)
 
         expect(userRepository.updateById).not.toHaveBeenCalled()
         expect(ctx.answerCallbackQuery).not.toHaveBeenCalled()
@@ -225,7 +225,7 @@ describe(ProHandler.name, () => {
           callbackQuery: { data: 'pro_send_invoice' },
         })
 
-        await handler.events['callback_query'](ctx)
+        await handler.events.callback_query(ctx)
 
         expect(configurationRepository.findGlobalConfig).toHaveBeenCalled()
         expect(ctx.answerCallbackQuery).toHaveBeenCalled()
@@ -251,7 +251,7 @@ describe(ProHandler.name, () => {
           callbackQuery: { data: 'pro_send_invoice' },
         })
 
-        await handler.events['callback_query'](ctx)
+        await handler.events.callback_query(ctx)
 
         expect(ctx.replyWithInvoice).toHaveBeenCalledWith(
           expect.any(String),
@@ -265,13 +265,13 @@ describe(ProHandler.name, () => {
 
       it('should do nothing if ctx.from is missing', async () => {
         const ctx = createMockContext({ from: undefined, callbackQuery: { data: 'pro_start_trial' } })
-        await handler.events['callback_query'](ctx)
+        await handler.events.callback_query(ctx)
         expect(userRepository.findByTelegramId).not.toHaveBeenCalled()
       })
 
       it('should do nothing if callback data is missing', async () => {
         const ctx = createMockContext({ callbackQuery: { data: undefined } })
-        await handler.events['callback_query'](ctx)
+        await handler.events.callback_query(ctx)
         expect(userRepository.findByTelegramId).not.toHaveBeenCalled()
       })
     })

--- a/src/handlers/pro.handler.spec.ts
+++ b/src/handlers/pro.handler.spec.ts
@@ -22,7 +22,7 @@ describe(ProHandler.name, () => {
     ...overrides,
   } as unknown as UserEntity)
 
-  const createMockContext = (overrides?: any): CustomContext => ({ t: (key: string) => key, from: { id: 12345 }, session: { command: null, params: null }, reply: vi.fn(), replyWithInvoice: vi.fn(), answerPreCheckoutQuery: vi.fn(), ...overrides } as unknown as CustomContext)
+  const createMockContext = (overrides?: any): CustomContext => ({ t: (key: string) => key, from: { id: 12345 }, session: { command: null, params: null }, reply: vi.fn(), replyWithInvoice: vi.fn(), answerPreCheckoutQuery: vi.fn(), answerCallbackQuery: vi.fn(), editMessageText: vi.fn(), ...overrides } as unknown as CustomContext)
 
   beforeEach(() => {
     userRepository = {
@@ -71,8 +71,8 @@ describe(ProHandler.name, () => {
       expect(ctx.session.command).toBeNull()
     })
 
-    it('should set session command and send invoice with pro_price from config', async () => {
-      const existingUser = createMockUser()
+    it('should set session command and send inline keyboard with trial and buy buttons', async () => {
+      const existingUser = createMockUser({ has_used_trial: false })
       vi.spyOn(userRepository, 'findByTelegramId').mockResolvedValueOnce(existingUser)
 
       const ctx = createMockContext()
@@ -80,41 +80,43 @@ describe(ProHandler.name, () => {
       await handler.onCommand(ctx)
 
       expect(ctx.session.command).toBe(CommandEnum.Pro)
-      expect(ctx.replyWithInvoice).toHaveBeenCalledWith(
-        'PDF Studio PRO',
-        'pro_upgrade',
-        'pdf-studio-pro-subscription',
-        CurrencyEnum.XTR,
-        [{ label: 'PRO Subscription', amount: 350 }],
-        {
-          provider_token: '',
-        },
-      )
+      expect(ctx.reply).toHaveBeenCalledWith('pro_upgrade', expect.objectContaining({
+        reply_markup: expect.any(Object),
+      }))
+      const replyCall = vi.mocked(ctx.reply).mock.calls[0]
+      const replyMarkup = replyCall[1]?.reply_markup as any
+      expect(replyMarkup.inline_keyboard[0][0].callback_data).toBe('pro_start_trial')
+      expect(replyMarkup.inline_keyboard[1][0].callback_data).toBe('pro_send_invoice')
     })
 
-    it('should use the pro_price from global config', async () => {
-      const existingUser = createMockUser()
+    it('should not show trial button if has_used_trial is true', async () => {
+      const existingUser = createMockUser({ has_used_trial: true })
       vi.spyOn(userRepository, 'findByTelegramId').mockResolvedValueOnce(existingUser)
-      vi.spyOn(configurationRepository, 'findGlobalConfig').mockResolvedValueOnce({
-        _id: 'global_config',
-        pro_price: 500,
-        created_at: new Date(),
-        updated_at: new Date(),
-      })
 
       const ctx = createMockContext()
 
       await handler.onCommand(ctx)
 
-      expect(configurationRepository.findGlobalConfig).toHaveBeenCalled()
-      expect(ctx.replyWithInvoice).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(String),
-        expect.any(String),
-        expect.any(String),
-        [{ label: 'PRO Subscription', amount: 500 }],
-        expect.any(Object),
-      )
+      expect(ctx.session.command).toBe(CommandEnum.Pro)
+      expect(ctx.reply).toHaveBeenCalledWith('pro_upgrade', expect.objectContaining({
+        reply_markup: expect.any(Object),
+      }))
+      const replyCall = vi.mocked(ctx.reply).mock.calls[0]
+      const replyMarkup = replyCall[1]?.reply_markup as any
+      expect(replyMarkup.inline_keyboard[0][0].callback_data).toBe('pro_send_invoice')
+      expect(replyMarkup.inline_keyboard).toHaveLength(1)
+    })
+
+    it('should tell the user if they are on ProTrial', async () => {
+      const existingUser = createMockUser({ plan_type: PlanTypeEnum.ProTrial })
+      vi.spyOn(userRepository, 'findByTelegramId').mockResolvedValueOnce(existingUser)
+
+      const ctx = createMockContext()
+
+      await handler.onCommand(ctx)
+
+      expect(ctx.reply).toHaveBeenCalledWith('pro_trial_active')
+      expect(ctx.session.command).toBeNull()
     })
 
     it('should do nothing if ctx.from is missing', async () => {
@@ -180,6 +182,97 @@ describe(ProHandler.name, () => {
 
         expect(userRepository.updateById).not.toHaveBeenCalled()
         expect(ctx.reply).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('callback_query', () => {
+      it('should start trial if data is pro_start_trial', async () => {
+        const existingUser = createMockUser({ has_used_trial: false })
+        vi.spyOn(userRepository, 'findByTelegramId').mockResolvedValueOnce(existingUser)
+
+        const ctx = createMockContext({
+          callbackQuery: { data: 'pro_start_trial' },
+        })
+
+        await handler.events['callback_query'](ctx)
+
+        expect(userRepository.updateById).toHaveBeenCalledWith('user-id', {
+          plan_type: PlanTypeEnum.ProTrial,
+          plan_started_at: expect.any(Date),
+          has_used_trial: true,
+        })
+        expect(ctx.answerCallbackQuery).toHaveBeenCalled()
+        expect(ctx.editMessageText).toHaveBeenCalledWith('pro_trial_started')
+        expect(ctx.session.command).toBeNull()
+      })
+
+      it('should not start trial if has_used_trial is true', async () => {
+        const existingUser = createMockUser({ has_used_trial: true })
+        vi.spyOn(userRepository, 'findByTelegramId').mockResolvedValueOnce(existingUser)
+
+        const ctx = createMockContext({
+          callbackQuery: { data: 'pro_start_trial' },
+        })
+
+        await handler.events['callback_query'](ctx)
+
+        expect(userRepository.updateById).not.toHaveBeenCalled()
+        expect(ctx.answerCallbackQuery).not.toHaveBeenCalled()
+      })
+
+      it('should send invoice if data is pro_send_invoice', async () => {
+        const ctx = createMockContext({
+          callbackQuery: { data: 'pro_send_invoice' },
+        })
+
+        await handler.events['callback_query'](ctx)
+
+        expect(configurationRepository.findGlobalConfig).toHaveBeenCalled()
+        expect(ctx.answerCallbackQuery).toHaveBeenCalled()
+        expect(ctx.replyWithInvoice).toHaveBeenCalledWith(
+          'PDF Studio PRO',
+          'pro_upgrade',
+          'pdf-studio-pro-subscription',
+          CurrencyEnum.XTR,
+          [{ label: 'PRO Subscription', amount: 350 }],
+          { provider_token: '' },
+        )
+      })
+
+      it('should use pro_price from config when sending invoice', async () => {
+        vi.spyOn(configurationRepository, 'findGlobalConfig').mockResolvedValueOnce({
+          _id: 'global_config',
+          pro_price: 500,
+          created_at: new Date(),
+          updated_at: new Date(),
+        } as any)
+
+        const ctx = createMockContext({
+          callbackQuery: { data: 'pro_send_invoice' },
+        })
+
+        await handler.events['callback_query'](ctx)
+
+        expect(ctx.replyWithInvoice).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.any(String),
+          expect.any(String),
+          expect.any(String),
+          [{ label: 'PRO Subscription', amount: 500 }],
+          expect.any(Object),
+        )
+      })
+
+      it('should do nothing if ctx.from is missing', async () => {
+        const ctx = createMockContext({ from: undefined, callbackQuery: { data: 'pro_start_trial' } })
+        await handler.events['callback_query'](ctx)
+        expect(userRepository.findByTelegramId).not.toHaveBeenCalled()
+      })
+
+      it('should do nothing if callback data is missing', async () => {
+        const ctx = createMockContext({ callbackQuery: { data: undefined } })
+        await handler.events['callback_query'](ctx)
+        expect(userRepository.findByTelegramId).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/handlers/pro.handler.ts
+++ b/src/handlers/pro.handler.ts
@@ -69,7 +69,8 @@ export class ProHandler extends BaseHandler {
           await ctx.editMessageText(ctx.t('pro_trial_started'))
           await this.resetSession(ctx)
         }
-      } else if (data === 'pro_send_invoice') {
+      }
+      else if (data === 'pro_send_invoice') {
         const { pro_price } = await this.configurationRepository.findGlobalConfig()
         await ctx.answerCallbackQuery()
         await ctx.replyWithInvoice(

--- a/src/handlers/pro.handler.ts
+++ b/src/handlers/pro.handler.ts
@@ -2,6 +2,7 @@ import type { ConfigurationRepository } from '../repositories/configuration.repo
 import type { PaymentRepository } from '../repositories/payment.repository'
 import type { UserRepository } from '../repositories/user.repository'
 import type { CustomContext } from '../types/custom-context.type'
+import { InlineKeyboard } from 'grammy'
 import { PaymentEntity } from '../entities/payment.entity'
 import { CommandEnum } from '../enums/command.enum'
 import { CurrencyEnum } from '../enums/currency.enum'
@@ -49,6 +50,40 @@ export class ProHandler extends BaseHandler {
 
       await this.resetSession(ctx)
     },
+    'callback_query': async (ctx: CustomContext) => {
+      const data = ctx.callbackQuery?.data
+      const userId = ctx.from?.id
+      if (!userId || !data) {
+        return
+      }
+
+      if (data === 'pro_start_trial') {
+        const user = await this.userRepository.findByTelegramId(userId)
+        if (user && !user.has_used_trial && user.plan_type !== PlanTypeEnum.Pro) {
+          await this.userRepository.updateById(user._id, {
+            plan_type: PlanTypeEnum.ProTrial,
+            plan_started_at: new Date(),
+            has_used_trial: true,
+          })
+          await ctx.answerCallbackQuery()
+          await ctx.editMessageText(ctx.t('pro_trial_started'))
+          await this.resetSession(ctx)
+        }
+      } else if (data === 'pro_send_invoice') {
+        const { pro_price } = await this.configurationRepository.findGlobalConfig()
+        await ctx.answerCallbackQuery()
+        await ctx.replyWithInvoice(
+          'PDF Studio PRO',
+          ctx.t('pro_upgrade'),
+          'pdf-studio-pro-subscription',
+          CurrencyEnum.XTR,
+          [{ label: 'PRO Subscription', amount: pro_price }],
+          {
+            provider_token: '',
+          },
+        )
+      }
+    },
   }
 
   async onCommand(ctx: CustomContext) {
@@ -65,19 +100,22 @@ export class ProHandler extends BaseHandler {
       return
     }
 
+    if (user?.plan_type === PlanTypeEnum.ProTrial) {
+      await ctx.reply(ctx.t('pro_trial_active'))
+      await this.resetSession(ctx)
+      return
+    }
+
     await this.setSessionCommand(ctx)
 
-    const { pro_price } = await this.configurationRepository.findGlobalConfig()
+    const keyboard = new InlineKeyboard()
+    if (!user?.has_used_trial) {
+      keyboard.text(ctx.t('pro_trial_button'), 'pro_start_trial').row()
+    }
+    keyboard.text(ctx.t('pro_buy_button'), 'pro_send_invoice')
 
-    await ctx.replyWithInvoice(
-      'PDF Studio PRO',
-      ctx.t('pro_upgrade'),
-      'pdf-studio-pro-subscription',
-      CurrencyEnum.XTR,
-      [{ label: 'PRO Subscription', amount: pro_price }],
-      {
-        provider_token: '',
-      },
-    )
+    await ctx.reply(ctx.t('pro_upgrade'), {
+      reply_markup: keyboard,
+    })
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -62,5 +62,9 @@
   "done": "done",
   "summary_prompt": "Create a concise yet informative summary of this PDF, structured with bullet points. Target length: ~2000 characters.",
   "unexpected_error": "❌ An unexpected error occurred. Please try again later.",
-  "reengagement_message": "We miss you at <b>PDF Studio</b>! 🎉\n\nCome back and check out our latest PDF tools. If you need any help, just type /help!"
+  "reengagement_message": "We miss you at <b>PDF Studio</b>! 🎉\n\nCome back and check out our latest PDF tools. If you need any help, just type /help!",
+  "pro_trial_active": "⏱️ You are currently on a 3-Day PRO Trial!",
+  "pro_trial_started": "🎉 Your 3-Day PRO Trial has started! Enjoy full access.",
+  "pro_trial_button": "🚀 Start 3-Day Free Trial",
+  "pro_buy_button": "💎 Subscribe to PRO"
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -62,5 +62,9 @@
   "done": "listo",
   "summary_prompt": "Crea un resumen conciso e informativo de este PDF, estructurado con viñetas (bullet points). Longitud objetivo: ~2000 caracteres.",
   "unexpected_error": "❌ Ocurrió un error inesperado. Por favor, inténtalo de nuevo más tarde.",
-  "reengagement_message": "¡Te extrañamos en <b>PDF Studio</b>! 🎉\n\nRegresa y descubre nuestras últimas herramientas para PDF. Si necesitas ayuda, ¡escribe /help!"
+  "reengagement_message": "¡Te extrañamos en <b>PDF Studio</b>! 🎉\n\nRegresa y descubre nuestras últimas herramientas para PDF. Si necesitas ayuda, ¡escribe /help!",
+  "pro_trial_active": "⏱️ ¡Actualmente estás en una prueba PRO de 3 días!",
+  "pro_trial_started": "🎉 ¡Tu prueba PRO de 3 días ha comenzado! Disfruta de acceso completo.",
+  "pro_trial_button": "🚀 Iniciar prueba gratuita de 3 días",
+  "pro_buy_button": "💎 Suscribirse a PRO"
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -62,5 +62,9 @@
   "done": "feito",
   "summary_prompt": "Crie um resumo conciso e informativo deste PDF, estruturado com marcadores (bullet points). Tamanho alvo: ~2000 caracteres.",
   "unexpected_error": "❌ Ocorreu um erro inesperado. Por favor, tente novamente mais tarde.",
-  "reengagement_message": "Sentimos sua falta no <b>PDF Studio</b>! 🎉\n\nVolte e confira nossas ferramentas de PDF mais recentes. Se precisar de ajuda, digite /help!"
+  "reengagement_message": "Sentimos sua falta no <b>PDF Studio</b>! 🎉\n\nVolte e confira nossas ferramentas de PDF mais recentes. Se precisar de ajuda, digite /help!",
+  "pro_trial_active": "⏱️ Você está atualmente em um teste PRO de 3 dias!",
+  "pro_trial_started": "🎉 Seu teste PRO de 3 dias começou! Aproveite o acesso total.",
+  "pro_trial_button": "🚀 Iniciar teste gratuito de 3 dias",
+  "pro_buy_button": "💎 Assinar PRO"
 }

--- a/src/middlewares/usage-limit.middleware.spec.ts
+++ b/src/middlewares/usage-limit.middleware.spec.ts
@@ -94,10 +94,68 @@ describe(usageLimitMiddleware.name, () => {
     expect(next).not.toHaveBeenCalled()
   })
 
+  it('should block if ProTrial user reaches limit (50)', async () => {
+    const user = {
+      _id: 'user-id',
+      plan_type: PlanTypeEnum.ProTrial,
+    }
+    vi.mocked(userRepository.findByTelegramId).mockResolvedValueOnce(user as any)
+    vi.mocked(userRepository.isWithinLimit).mockResolvedValueOnce(false)
+
+    const middleware = usageLimitMiddleware(handler)
+    await middleware(ctx, next)
+
+    expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining('pro_limit_reached'))
+    expect(next).not.toHaveBeenCalled()
+  })
+
   it('should allow if Pro user is within limit', async () => {
     const user = {
       _id: 'user-id',
       plan_type: PlanTypeEnum.Pro,
+    }
+    vi.mocked(userRepository.findByTelegramId).mockResolvedValueOnce(user as any)
+    vi.mocked(userRepository.isWithinLimit).mockResolvedValueOnce(true)
+
+    const middleware = usageLimitMiddleware(handler)
+    await middleware(ctx, next)
+
+    expect(userRepository.updateById).not.toHaveBeenCalled()
+    expect(userRepository.isWithinLimit).toHaveBeenCalledWith(12345, 50)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should revert to Free if ProTrial plan has expired (3 days)', async () => {
+    const expiredDate = new Date()
+    expiredDate.setDate(expiredDate.getDate() - 4)
+
+    const user = {
+      _id: 'user-id',
+      plan_type: PlanTypeEnum.ProTrial,
+      plan_started_at: expiredDate,
+    }
+    vi.mocked(userRepository.findByTelegramId).mockResolvedValueOnce(user as any)
+    vi.mocked(userRepository.isWithinLimit).mockResolvedValueOnce(true)
+
+    const middleware = usageLimitMiddleware(handler)
+    await middleware(ctx, next)
+
+    expect(userRepository.updateById).toHaveBeenCalledWith('user-id', {
+      plan_type: PlanTypeEnum.Free,
+      plan_started_at: null,
+    })
+    expect(userRepository.isWithinLimit).toHaveBeenCalledWith(12345, 3)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should not revert to Free if ProTrial plan has not expired', async () => {
+    const recentDate = new Date()
+    recentDate.setDate(recentDate.getDate() - 2)
+
+    const user = {
+      _id: 'user-id',
+      plan_type: PlanTypeEnum.ProTrial,
+      plan_started_at: recentDate,
     }
     vi.mocked(userRepository.findByTelegramId).mockResolvedValueOnce(user as any)
     vi.mocked(userRepository.isWithinLimit).mockResolvedValueOnce(true)

--- a/src/middlewares/usage-limit.middleware.ts
+++ b/src/middlewares/usage-limit.middleware.ts
@@ -31,10 +31,20 @@ export function usageLimitMiddleware(handler: BaseHandler) {
         user.plan_type = PlanTypeEnum.Free
       }
     }
+    else if (user.plan_type === PlanTypeEnum.ProTrial && user.plan_started_at) {
+      const threeDaysAgo = new Date()
+      threeDaysAgo.setDate(threeDaysAgo.getDate() - 3) // 3 days expiration
+
+      if (user.plan_started_at < threeDaysAgo) {
+        await userRepository.updateById(user._id, { plan_type: PlanTypeEnum.Free, plan_started_at: null })
+        user.plan_type = PlanTypeEnum.Free
+      }
+    }
 
     const limits = {
       [PlanTypeEnum.Free]: 3,
       [PlanTypeEnum.Pro]: 50,
+      [PlanTypeEnum.ProTrial]: 50,
     }
 
     const limit = limits[user.plan_type || PlanTypeEnum.Free]
@@ -42,7 +52,7 @@ export function usageLimitMiddleware(handler: BaseHandler) {
     const isWithinLimit = await userRepository.isWithinLimit(ctx.from!.id, limit)
 
     if (!isWithinLimit) {
-      if (user.plan_type === PlanTypeEnum.Pro) {
+      if (user.plan_type === PlanTypeEnum.Pro || user.plan_type === PlanTypeEnum.ProTrial) {
         await ctx.reply(ctx.t('pro_limit_reached'))
       }
       else {

--- a/src/repositories/user.repository.spec.ts
+++ b/src/repositories/user.repository.spec.ts
@@ -42,6 +42,7 @@ describe(UserRepository.name, () => {
       language: 'en',
       created_at: expect.any(Date),
       updated_at: expect.any(Date),
+      has_used_trial: false,
     })
   })
 

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -44,6 +44,9 @@ export class UserRepository extends BaseRepository<UserEntity> {
             updated_at: {
               bsonType: 'date',
             },
+            has_used_trial: {
+              bsonType: 'bool',
+            },
           },
         },
       },


### PR DESCRIPTION
Implements a 3-day trial feature for the Pro plan as requested. Users who haven't used the trial before can start it via the `/pro` command inline keyboard. The trial grants a limit of 50 operations per day and automatically expires 3 days after activation.

---
*PR created automatically by Jules for task [5934730279573900174](https://jules.google.com/task/5934730279573900174) started by @gabrielrufino*