### PR TITLE
🧪 [Test Improvement] Add Error Path Test for pdf-to-images handler fs.rm failure

### DIFF
--- a/src/handlers/pdf-to-images.handler.spec.ts
+++ b/src/handlers/pdf-to-images.handler.spec.ts
@@ -136,6 +136,28 @@ describe(PdfToImagesHandler.name, () => {
         expect(loggerSpy).toHaveBeenCalledWith(expect.objectContaining({ error: expect.any(Error) }), expect.stringContaining('Failed to remove'))
       })
 
+      it('should log error if removing input file fails', async () => {
+        ctx.session.command = CommandEnum.PdfToImages
+        const mockImages = [Buffer.from([1, 2, 3])]
+        const mockDocument = {
+          length: 1,
+          [Symbol.asyncIterator]: vi.fn().mockReturnValue(mockImages[Symbol.iterator]()),
+        }
+        vi.mocked(pdf).mockResolvedValue(mockDocument as any)
+
+        const fs = await import('node:fs/promises')
+        vi.mocked(fs.default.rm).mockImplementation(async (path) => {
+          if (path === '/tmp/test.pdf') {
+            throw new Error('rm input failed')
+          }
+        })
+        const loggerSpy = vi.spyOn((handler as any).logger, 'error')
+
+        await handler.events['msg:document'](ctx)
+
+        expect(loggerSpy).toHaveBeenCalledWith(expect.objectContaining({ error: expect.any(Error) }), 'Failed to remove input file.')
+      })
+
       it('should handle errors during conversion', async () => {
         ctx.session.command = CommandEnum.PdfToImages
         vi.mocked(pdf).mockRejectedValue(new Error('Conversion failed'))


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing test for the error path when `fs.rm` fails to remove the input file in the `PdfToImagesHandler`'s `finally` block.
📊 **Coverage:** The new scenario tested is `fs.rm` throwing an error when called with the `inputPath`, and it expects the `logger.error` to be called with "Failed to remove input file.".
✨ **Result:** Test coverage and reliability of the `PdfToImagesHandler` cleanup code are improved.

---
*PR created automatically by Jules for task [11110909667802563487](https://jules.google.com/task/11110909667802563487) started by @gabrielrufino*