### PR TITLE
🧹 refactor: replace catch `any` with `unknown` and implement type narrowing

### DIFF
--- a/src/handlers/download.handler.ts
+++ b/src/handlers/download.handler.ts
@@ -111,8 +111,8 @@ export class DownloadHandler extends BaseHandler {
         }
       }
     }
-    catch (error: any) {
-      if (error.message === 'URL resolves to a private IP address') {
+    catch (error: unknown) {
+      if (error instanceof Error && error.message === 'URL resolves to a private IP address') {
         throw error
       }
       // Ignore resolution errors, as they'll be handled by Puppeteer

--- a/src/handlers/summary.handler.ts
+++ b/src/handlers/summary.handler.ts
@@ -129,8 +129,8 @@ export class SummaryHandler extends BaseHandler {
         })
         break
       }
-      catch (error: any) {
-        if (error.status === 503 && i < maxRetries - 1) {
+      catch (error: unknown) {
+        if (error instanceof Error && 'status' in error && error.status === 503 && i < maxRetries - 1) {
           this.logger.warn({ error, attempt: i + 1 }, 'Gemini API 503 error, retrying...')
           await new Promise(resolve => setTimeout(resolve, delay))
           delay *= 2

--- a/src/jobs/reengagement.job.ts
+++ b/src/jobs/reengagement.job.ts
@@ -25,7 +25,7 @@ export function initReengagementJob() {
           // Sleep for 50ms to respect rate limits (max 30 messages per second)
           await new Promise(resolve => setTimeout(resolve, 50))
         }
-        catch (error: any) {
+        catch (error: unknown) {
           logger.error({ error, userId: user.telegram_user.id }, 'Failed to send re-engagement message')
         }
       }


### PR DESCRIPTION
🎯 **What:** Replaced `catch (error: any)` with `catch (error: unknown)` and applied proper type guards in `summary.handler.ts`, `download.handler.ts`, and `reengagement.job.ts`.

💡 **Why:** Using `any` in catch blocks disables TypeScript's type checking, which can lead to runtime errors when accessing properties that might not exist on the thrown object. By using `unknown` combined with type narrowing (like `error instanceof Error` and `'status' in error`), the code becomes much safer, more robust, and adheres better to modern TypeScript best practices and linting standards.

✅ **Verification:** Verified by running `pnpm test` (all tests passed) and `npm run lint` (no linting errors). Code review also confirmed the change is correct and safe.

✨ **Result:** Improved code health and maintainability across multiple files by eliminating a potential source of type-safety issues during error handling without altering any existing behavior.

---
*PR created automatically by Jules for task [2157727169856558527](https://jules.google.com/task/2157727169856558527) started by @gabrielrufino*