### PR TITLE
🔒 Fix string format injection in template replacement

### DIFF
--- a/src/handlers/join.handler.spec.ts
+++ b/src/handlers/join.handler.spec.ts
@@ -72,6 +72,26 @@ describe(JoinHandler.name, () => {
 
         await expect(handler.events['msg:document'](ctx)).rejects.toThrow(SessionValidationError)
       })
+
+      it('should not be vulnerable to string format injection via file_name', async () => {
+        const filePath = '/tmp/file.pdf'
+        vi.mocked(ctx.getFile).mockResolvedValueOnce({
+          download: vi.fn().mockResolvedValue(filePath),
+        } as any)
+
+        ctx.message!.document!.file_name = 'malicious_{current}_{max}.pdf'
+        ctx.t = (key: string) => {
+          if (key === 'join_file_received') {
+            return 'File {name} received. {current}/{max}'
+          }
+          return key
+        }
+
+        await handler.events['msg:document'](ctx)
+
+        expect(ctx.getFile).toHaveBeenCalled()
+        expect(ctx.reply).toHaveBeenCalledWith('File malicious_{current}_{max}.pdf received. 1/10')
+      })
     })
 
     describe('msg:document (limit reached)', () => {

--- a/src/handlers/join.handler.ts
+++ b/src/handlers/join.handler.ts
@@ -11,6 +11,7 @@ import { PlanTypeEnum } from '../enums/plan-type.enum'
 import { LimitExceededError } from '../errors/limit-exceeded.error'
 import { UserNotFoundError } from '../errors/user-not-found.error'
 import { JoinParamsSchema } from '../schemas/join-params.schema'
+import { formatString } from '../utils/format.util'
 import { BaseHandler } from './base.handler'
 
 export class JoinHandler extends BaseHandler {
@@ -26,7 +27,9 @@ export class JoinHandler extends BaseHandler {
       const params = this.validateParams(JoinParamsSchema, ctx.session.params)
 
       if (params.paths.length >= JoinHandler.MAX_PDF_FILES) {
-        await ctx.reply(ctx.t('join_limit_reached').replace('{max}', JoinHandler.MAX_PDF_FILES.toString()))
+        await ctx.reply(formatString(ctx.t('join_limit_reached'), {
+          max: JoinHandler.MAX_PDF_FILES.toString(),
+        }))
         return
       }
 
@@ -49,10 +52,11 @@ export class JoinHandler extends BaseHandler {
       ctx.session.params = params
 
       await ctx.reply(
-        ctx.t('join_file_received')
-          .replace('{name}', ctx.message?.document?.file_name || 'file')
-          .replace('{current}', params.paths.length.toString())
-          .replace('{max}', JoinHandler.MAX_PDF_FILES.toString()),
+        formatString(ctx.t('join_file_received'), {
+          name: ctx.message?.document?.file_name || 'file',
+          current: params.paths.length.toString(),
+          max: JoinHandler.MAX_PDF_FILES.toString(),
+        }),
       )
     },
     'msg:text': async (ctx: CustomContext) => {
@@ -71,7 +75,9 @@ export class JoinHandler extends BaseHandler {
     await this.setSessionCommand(ctx)
     ctx.session.params = { paths: [] }
     await ctx.reply(
-      ctx.t('join_send_files').replace('{max}', JoinHandler.MAX_PDF_FILES.toString()),
+      formatString(ctx.t('join_send_files'), {
+        max: JoinHandler.MAX_PDF_FILES.toString(),
+      }),
     )
   }
 

--- a/src/handlers/version.handler.ts
+++ b/src/handlers/version.handler.ts
@@ -1,6 +1,7 @@
 import type { CustomContext } from '../types/custom-context.type'
 import { version } from '../../package.json'
 import { CommandEnum } from '../enums/command.enum'
+import { formatString } from '../utils/format.util'
 import { BaseHandler } from './base.handler'
 
 export class VersionHandler extends BaseHandler {
@@ -10,6 +11,6 @@ export class VersionHandler extends BaseHandler {
   public readonly events = {}
 
   async onCommand(ctx: CustomContext) {
-    await ctx.reply(ctx.t('version_info').replace('{version}', version), { parse_mode: 'HTML' })
+    await ctx.reply(formatString(ctx.t('version_info'), { version }), { parse_mode: 'HTML' })
   }
 }

--- a/src/utils/format.util.ts
+++ b/src/utils/format.util.ts
@@ -1,0 +1,3 @@
+export function formatString(template: string, replacements: Record<string, string>): string {
+  return template.replace(/{(\w+)}/g, (match, key) => replacements[key] !== undefined ? replacements[key] : match)
+}

--- a/src/utils/format.util.ts
+++ b/src/utils/format.util.ts
@@ -1,3 +1,3 @@
 export function formatString(template: string, replacements: Record<string, string>): string {
-  return template.replace(/{(\w+)}/g, (match, key) => replacements[key] !== undefined ? replacements[key] : match)
+  return template.replace(/\{(\w+)\}/g, (match, key) => replacements[key] !== undefined ? replacements[key] : match)
 }


### PR DESCRIPTION
Fixes a string format injection vulnerability where chained `.replace()` calls allowed user input containing placeholders (e.g., `{current}`) to inadvertently replace subsequent template variables. Implemented a `formatString` utility function using regex with a replacer callback to securely handle variable interpolation without rescanning replaced values.

---
*PR created automatically by Jules for task [10716143037876558378](https://jules.google.com/task/10716143037876558378) started by @gabrielrufino*