### PR TITLE
🔒 fix(browser): remove insecure puppeteer sandbox flags

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -6,6 +6,10 @@ services:
       target: ${BUILD_TARGET:-production}
     container_name: pdf-studio-bot
     restart: unless-stopped
+    cap_add:
+      - SYS_ADMIN
+    security_opt:
+      - seccomp=unconfined
     env_file:
       - .env
     environment:

--- a/src/config/browser.spec.ts
+++ b/src/config/browser.spec.ts
@@ -32,8 +32,6 @@ describe('browser config', () => {
 
     expect(puppeteer.launch).toHaveBeenCalledWith({
       args: [
-        '--no-sandbox',
-        '--disable-setuid-sandbox',
         '--disable-dev-shm-usage',
         '--disable-gpu',
       ],
@@ -49,12 +47,8 @@ describe('browser config', () => {
 
     expect(puppeteer.launch).toHaveBeenCalledWith({
       args: [
-        '--no-sandbox',
-        '--disable-setuid-sandbox',
         '--disable-dev-shm-usage',
         '--disable-gpu',
-        '--no-zygote',
-        '--single-process',
       ],
       headless: true,
       timeout: 30000,

--- a/src/config/browser.ts
+++ b/src/config/browser.ts
@@ -7,8 +7,6 @@ export class Browser {
   private getBrowserConfig() {
     const baseConfig = {
       args: [
-        '--no-sandbox',
-        '--disable-setuid-sandbox',
         '--disable-dev-shm-usage',
         '--disable-gpu',
       ],
@@ -22,8 +20,6 @@ export class Browser {
         executablePath: '/usr/bin/chromium-browser',
         args: [
           ...baseConfig.args,
-          '--no-zygote',
-          '--single-process',
         ],
       }
     }


### PR DESCRIPTION
🎯 **What:** Removed insecure `--no-sandbox` flags from the Puppeteer configuration and enabled proper sandboxing for Chromium inside the Docker container.
⚠️ **Risk:** Running Chromium without its sandbox (`--no-sandbox`, `--disable-setuid-sandbox`) allows a compromised or malicious webpage processed by the application (e.g., in the `/download` handler) to easily achieve Remote Code Execution (RCE) on the host machine.
🛡️ **Solution:** Removed the anti-sandbox flags from the `baseConfig` and the production override in `src/config/browser.ts`. Updated `compose.yml` to grant the container the `SYS_ADMIN` capability and `seccomp=unconfined`, which are necessary permissions for Chrome to initialize its user namespace sandbox within a Docker environment.

---
*PR created automatically by Jules for task [14096648767483015212](https://jules.google.com/task/14096648767483015212) started by @gabrielrufino*