### PR TITLE
🔒 fix: enforce max pages limit for pro users to prevent resource exhaustion

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,2 +1,3 @@
 export const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB
 export const MAX_PAGES = 50
+export const MAX_PRO_PAGES = 500

--- a/src/handlers/pdf-to-images.handler.ts
+++ b/src/handlers/pdf-to-images.handler.ts
@@ -6,7 +6,7 @@ import os from 'node:os'
 import { join } from 'node:path'
 import { InputFile } from 'grammy'
 import { pdf } from 'pdf-to-img'
-import { MAX_FILE_SIZE, MAX_PAGES } from '../config/constants'
+import { MAX_FILE_SIZE, MAX_PAGES, MAX_PRO_PAGES } from '../config/constants'
 import { CommandEnum } from '../enums/command.enum'
 import { PlanTypeEnum } from '../enums/plan-type.enum'
 import { InvalidFileError } from '../errors/invalid-file.error'
@@ -53,7 +53,10 @@ export class PdfToImagesHandler extends BaseHandler {
         const document = await pdf(inputPath)
         const totalPages = document.length
 
-        if (user.plan_type !== PlanTypeEnum.Pro && totalPages > MAX_PAGES) {
+        if (
+          (user.plan_type !== PlanTypeEnum.Pro && totalPages > MAX_PAGES)
+          || (user.plan_type === PlanTypeEnum.Pro && totalPages > MAX_PRO_PAGES)
+        ) {
           await this.notifyLimitExceeded(ctx)
           throw new LimitExceededError()
         }

--- a/src/handlers/split.handler.ts
+++ b/src/handlers/split.handler.ts
@@ -5,7 +5,7 @@ import os from 'node:os'
 import { join } from 'node:path'
 import { InputFile } from 'grammy'
 import muhammara from 'muhammara'
-import { MAX_FILE_SIZE, MAX_PAGES } from '../config/constants'
+import { MAX_FILE_SIZE, MAX_PAGES, MAX_PRO_PAGES } from '../config/constants'
 import { CommandEnum } from '../enums/command.enum'
 import { PlanTypeEnum } from '../enums/plan-type.enum'
 import { LimitExceededError } from '../errors/limit-exceeded.error'
@@ -50,7 +50,10 @@ export class SplitHandler extends BaseHandler {
         const pdfReader = muhammara.createReader(inputPath)
         const pagesCount = pdfReader.getPagesCount()
 
-        if (user.plan_type !== PlanTypeEnum.Pro && pagesCount > MAX_PAGES) {
+        if (
+          (user.plan_type !== PlanTypeEnum.Pro && pagesCount > MAX_PAGES)
+          || (user.plan_type === PlanTypeEnum.Pro && pagesCount > MAX_PRO_PAGES)
+        ) {
           await this.notifyLimitExceeded(ctx)
           throw new LimitExceededError()
         }


### PR DESCRIPTION
🎯 **What:** Enforced a maximum page limit (`MAX_PRO_PAGES = 500`) for Pro users when processing PDFs in the `pdf-to-images` and `split` handlers.
⚠️ **Risk:** Without an upper limit, a malicious or unintentional request with a massive PDF (e.g., thousands of pages) could exhaust CPU, RAM, and disk space while attempting to split or render pages into images, leading to a Denial of Service (DoS).
🛡️ **Solution:** Added a new constant `MAX_PRO_PAGES` in `src/config/constants.ts` and updated the handlers (`pdf-to-images.handler.ts` and `split.handler.ts`) to throw a `LimitExceededError` if the page count exceeds this limit for Pro users. Free users continue to be restricted by `MAX_PAGES`.

---
*PR created automatically by Jules for task [3576831513284222833](https://jules.google.com/task/3576831513284222833) started by @gabrielrufino*