### PR TITLE
🔒 Fix sensitive data exposure in bot configuration logger

### DIFF
--- a/src/config/bot.ts
+++ b/src/config/bot.ts
@@ -36,7 +36,7 @@ bot.use(
     getSessionKey: (ctx) => {
       const id = ctx.from?.id || ctx.chat?.id
       if (!id) {
-        logger.warn({ update: ctx.update }, 'Session key could not be determined for update')
+        logger.warn({ update_id: ctx.update?.update_id }, 'Session key could not be determined for update')
         return undefined
       }
       return id.toString()


### PR DESCRIPTION
🎯 **What:** The full `ctx.update` object was being logged in `src/config/bot.ts` when a session key could not be determined.
⚠️ **Risk:** `ctx.update` contains sensitive PII including user IDs, names, and message payloads, which the application's internal redactor does not cover, leading to unauthorized data exposure in logs.
🛡️ **Solution:** Modified the logger to only record `update_id: ctx.update?.update_id` instead of the full object, ensuring traceability without leaking sensitive information.

---
*PR created automatically by Jules for task [15417371796218931794](https://jules.google.com/task/15417371796218931794) started by @gabrielrufino*