### PR TITLE
🔒 fix(security): Enable Chromium sandboxing for PDF processing

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -12,3 +12,7 @@ services:
       - NODE_ENV=production
     volumes:
       - ./logs:/app/logs
+    cap_add:
+      - SYS_ADMIN
+    security_opt:
+      - seccomp=unconfined

--- a/src/config/browser.spec.ts
+++ b/src/config/browser.spec.ts
@@ -32,8 +32,6 @@ describe('browser config', () => {
 
     expect(puppeteer.launch).toHaveBeenCalledWith({
       args: [
-        '--no-sandbox',
-        '--disable-setuid-sandbox',
         '--disable-dev-shm-usage',
         '--disable-gpu',
       ],
@@ -49,12 +47,8 @@ describe('browser config', () => {
 
     expect(puppeteer.launch).toHaveBeenCalledWith({
       args: [
-        '--no-sandbox',
-        '--disable-setuid-sandbox',
         '--disable-dev-shm-usage',
         '--disable-gpu',
-        '--no-zygote',
-        '--single-process',
       ],
       headless: true,
       timeout: 30000,

--- a/src/config/browser.ts
+++ b/src/config/browser.ts
@@ -7,8 +7,6 @@ export class Browser {
   private getBrowserConfig() {
     const baseConfig = {
       args: [
-        '--no-sandbox',
-        '--disable-setuid-sandbox',
         '--disable-dev-shm-usage',
         '--disable-gpu',
       ],
@@ -22,8 +20,6 @@ export class Browser {
         executablePath: '/usr/bin/chromium-browser',
         args: [
           ...baseConfig.args,
-          '--no-zygote',
-          '--single-process',
         ],
       }
     }


### PR DESCRIPTION
🎯 **What:** Removed insecure flags (`--no-sandbox`, `--disable-setuid-sandbox`, `--single-process`, and `--no-zygote`) from the base and production Puppeteer configurations, effectively re-enabling Chromium's security sandbox. Additionally, updated `compose.yml` to grant the container the necessary capabilities (`SYS_ADMIN` and `seccomp=unconfined`) to support the sandbox.

⚠️ **Risk:** Running Chromium without sandboxing is highly dangerous, especially when processing untrusted, user-supplied PDF files. Without the sandbox, any vulnerability exploited in the rendering engine could lead to full host compromise (RCE).

🛡️ **Solution:** Restored the default Chromium sandbox by removing the disabling arguments in `src/config/browser.ts`. Configured the Docker environment via `compose.yml` to support the user namespaces required by the Chromium sandbox in containerized environments. Tests were updated to reflect the new expected launch arguments.

---
*PR created automatically by Jules for task [13917704411076127033](https://jules.google.com/task/13917704411076127033) started by @gabrielrufino*